### PR TITLE
[Fix] 64 bit Server doesn't support architecture 'i386' for MariaDB Repo

### DIFF
--- a/wo/core/variables.py
+++ b/wo/core/variables.py
@@ -142,11 +142,11 @@ class WOVariables():
 
     # MySQL repo and packages
     if wo_platform_distro == 'ubuntu':
-        wo_mysql_repo = ("deb [arch=amd64,i386,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/"
+        wo_mysql_repo = ("deb [arch=amd64,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/"
                          "10.3/ubuntu {codename} main"
                          .format(codename=wo_platform_codename))
     elif wo_platform_distro == 'debian':
-        wo_mysql_repo = ("deb [arch=amd64,i386,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/"
+        wo_mysql_repo = ("deb [arch=amd64,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/"
                          "10.3/debian {codename} main"
                          .format(codename=wo_platform_codename))
 


### PR DESCRIPTION
[Fix] 64 bit Server doesn't support architecture 'i386' for MariaDB Repo

This PR fixes the issue an i386 architecture error message on 64bit Server while doing the APT update. 

Error Msg: 
`N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.3/ubuntu bionic InRelease' doesn't support architecture 'i386'`
