### PR TITLE
Issue #81 update stub_status to php72-fpm.sock & avoid 502

### DIFF
--- a/wo/cli/templates/stub_status.mustache
+++ b/wo/cli/templates/stub_status.mustache
@@ -2,7 +2,7 @@
 # DO NOT MODIFY, ALL CHANGES WILL BE LOST AFTER AN WordOps (wo) UPDATE
 {{#phpconf}}
 upstream phpstatus {
-    server unix:/run/php/php7.2-fpm.sock;
+    server unix:/run/php/php72-fpm.sock;
 }
 {{/phpconf}}
 server {


### PR DESCRIPTION
Currently it uses php7.2-fpm.sock while the actual socket file name is php72-fpm.sock

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Additional Information
