### PR TITLE
typo

### DIFF
--- a/wo/cli/plugins/site.py
+++ b/wo/cli/plugins/site.py
@@ -982,7 +982,7 @@ class WOSiteUpdateController(CementBaseController):
         if (pargs.hsts and not (pargs.html or
                                 pargs.php or pargs.php73 or pargs.mysql or
                                 pargs.wp or pargs.wpfc or pargs.wpsc or
-                                pargs.wprocket or parge.wpce or
+                                pargs.wprocket or pargs.wpce or
                                 pargs.wpsubdir or pargs.wpsubdomain or
                                 pargs.password)):
             try:


### PR DESCRIPTION
When i try to enable HSTS option I keep getting name 'parge' is not defined. Only parge in repo is here. I think there is a typo.