### PR TITLE
fix cheat install

### DIFF
--- a/install
+++ b/install
@@ -797,10 +797,9 @@ wo_ufw_setup() {
 
 wo_cheat_install() {
     curl -sL https://cht.sh/:cht.sh > /usr/local/bin/cht.sh
+    chmod +x /usr/local/bin/cht.sh
+    ln -s /usr/local/bin/cht.sh /usr/local/bin/cheat 
     curl -sL https://cheat.sh/:bash_completion > /etc/bash_completion.d/cht.sh
-    if ! grep -q "cheat" $HOME/.bashrc; then
-        echo "alias cheat='/usr/local/bin/cht.sh'" >> "$HOME/.bashrc"
-    fi
 }
 
 ###


### PR DESCRIPTION
1. make script executable or it won’t work
2. instead of writing to user’s dotfiles, create a symbolic link with the script alias.