### PR TITLE
Protect Easy Digital Download files from being accessed directly

### DIFF
--- a/wo/cli/templates/locations.mustache
+++ b/wo/cli/templates/locations.mustache
@@ -58,6 +58,12 @@ location ~* "(eval\()" {
     deny all;
 }
 
+# Protect Easy Digital Download files from being accessed directly.
+location ~ ^/wp-content/uploads/edd/(.*?)\.zip$ { 
+    rewrite / permanent; 
+}
+
+
 # Additional security settings
 
 location ~* "(127\.0\.0\.1)" {

--- a/wo/cli/templates/locations.mustache
+++ b/wo/cli/templates/locations.mustache
@@ -63,7 +63,6 @@ location ~ ^/wp-content/uploads/edd/(.*?)\.zip$ {
     rewrite / permanent; 
 }
 
-
 # Additional security settings
 
 location ~* "(127\.0\.0\.1)" {


### PR DESCRIPTION
##### Summary

Protect Easy Digital Download files from being accessed directly. 
Otherwise anyone could bypass the EDD purchase and download files directly from the server.

This method is recommended by EDD themselves. Let me know if there's another preferred method. 

Thanks guys! 🙌

##### Additional Information
https://docs.easydigitaldownloads.com/article/682-protected-download-files-on-nginx