### PR TITLE
Protect Easy Digital Download files from being accessed directly.

### DIFF
--- a/wo/cli/templates/wpcommon.mustache
+++ b/wo/cli/templates/wpcommon.mustache
@@ -94,3 +94,7 @@ location ~* /(?:uploads|files)/.*\.php$ {
 location ~ \/wp-admin\/load-(scripts|styles).php {
     deny all;
 }
+# Protect Easy Digital Download files from being accessed directly.
+location ~ ^/wp-content/uploads/edd/(.*?)\.zip$ { 
+    rewrite / permanent; 
+}


### PR DESCRIPTION
##### Summary

This pull request replaces  #221 

Easy Digital Download files won't be able to be downloaded directly from the server. 

##### Additional Information

https://docs.easydigitaldownloads.com/article/682-protected-download-files-on-nginx
