### PR TITLE
Update virtualconf.mustache to enable IPv6 for vhost

### DIFF
--- a/wo/cli/templates/virtualconf.mustache
+++ b/wo/cli/templates/virtualconf.mustache
@@ -1,6 +1,8 @@
 
 server {
-
+    listen :80;
+    listen [::]:80;
+    
     {{#multisite}}
     # Uncomment the following line for domain mapping
     # listen 80 default_server;


### PR DESCRIPTION
added listen for IPv4 and IPv6

ensure vhosts are IPv6 able

listen :80; is implicit but now but it is better to include for completeness

not sure how to handle the multisite instruction for domain mapping