### PR TITLE
Enable Letsencrypt installation on sites that use basic auth

### DIFF
--- a/wo/cli/templates/locations.mustache
+++ b/wo/cli/templates/locations.mustache
@@ -35,6 +35,7 @@ location ~ /\.(?!well-known\/) {
 location /.well-known/acme-challenge/ {
    alias /var/www/html/.well-known/acme-challenge/;
    allow all;
+   auth_basic off;
 }
 # Return 403 forbidden for readme.(txt|html) or license.(txt|html) or example.(txt|html) or other common git repository files
 location ~*  "/(^$|readme|license|example|README|LEGALNOTICE|INSTALLATION|CHANGELOG)\.(txt|html|md)" {

--- a/wo/cli/templates/virtualconf.mustache
+++ b/wo/cli/templates/virtualconf.mustache
@@ -33,6 +33,7 @@ server {
     location /.well-known/acme-challenge/ {
         alias /var/www/html/.well-known/acme-challenge/;
         allow all;
+        auth_basic off;
     }
     {{/proxy}}
 


### PR DESCRIPTION
Enable valid reponse from https://domain.tld/.well-known/acme-challenge/ in case site uses Basic Auth.

If not set, a `wo site update domain.tld --le` fails.