### PR TITLE
Add --allow-root to search-replace in SSL.siteurlhttps.

### DIFF
--- a/wo/core/sslutils.py
+++ b/wo/core/sslutils.py
@@ -101,7 +101,7 @@ class SSL:
                     WOShellExec.cmd_exec(
                         self, "{0} search-replace \'http://{1}\'"
                         "\'https://{1}\' --skip-columns=guid "
-                        "--skip-tables=wp_users"
+                        "--skip-tables=wp_users --allow-root"
                         .format(WOVar.wo_wpcli_path, domain))
                 except Exception as e:
                     Log.debug(self, str(e))


### PR DESCRIPTION
### Summary

`--allow-root` is missing from the `search-replace` part in `SSL.siteurlhttps`.

##### Additional Information

`--allow-root` is added to the other commands in this method.