### PR TITLE
Updated caching rules

### DIFF
--- a/wo/cli/templates/map-wp.mustache
+++ b/wo/cli/templates/map-wp.mustache
@@ -36,11 +36,10 @@ map $request_uri $uri_no_cache {
     "~*/wp-comments-popup.php" 1;
     "~*/wp-links-opml.php" 1;
     "~*/xmlrpc.php" 1;
-    "~*/checkout" 1;
-    "~*/edd_action" 1;
     "~*/edd-sl/*" 1;
     "~*/add_to_cart/" 1;
     "~*/cart/" 1;
+    "~*/account/" 1;
     "~*/my-account/" 1;
     "~*/checkout/" 1;
     "~*/addons/" 1;


### PR DESCRIPTION
Removed `/edd_action` as it's actually `/?edd_action`. a query string. They are removed by default.

Removed `/checkout` as we already have `/checkout/` (One of my plugins has the URL of /checkout-countdown../ and was never cached.) 

Added `/account/` as it's a common page that shouldn't be cached.
