### PR TITLE
Fix: GRANT works for all MySQL/MariaDB variants

### DIFF
--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -219,7 +219,7 @@ def setupdatabase(self, data):
     Log.debug(self, "Setting up user privileges")
     try:
         WOMysql.execute(self,
-                        "grant all privileges on `{0}`.* to `{1}`@`{2}`"
+                        "grant select, insert, update, delete, create, drop, references, index, alter, create temporary tables, lock tables, execute, create view, show view, create routine, alter routine, event, trigger on `{0}`.* to `{1}`@`{2}`"
                         .format(wo_db_name,
                                 wo_db_username, wo_mysql_grant_host))
     except StatementExcecutionError:


### PR DESCRIPTION
Including AWS RDS MariaDB. See https://github.com/WordOps/WordOps/issues/263

Fixes #263.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

GRANT statement that works for all MySQL/MariaDB variants.

##### Additional Information

AWS RDS MariaDB security policies blocks "all privileges" to be granted.

My personal opinion is that this is also a good security practice to request specifically that needed privileges. Especially as WordPress and its plugins have been targeted for attacks.