### PR TITLE
Exclude the status page itself in traffic calculation

### DIFF
--- a/wo/cli/templates/22222.mustache
+++ b/wo/cli/templates/22222.mustache
@@ -21,8 +21,10 @@ server {
 
   # nginx-vts-status
   location /vts_status {
-  vhost_traffic_status_display;
-  vhost_traffic_status_display_format html;
+    vhost_traffic_status_bypass_limit on;
+    vhost_traffic_status_bypass_stats on;
+    vhost_traffic_status_display;
+    vhost_traffic_status_display_format html;
   }
 
   location / {


### PR DESCRIPTION
When viewing traffic on `domain.tld:22222/vts_status`, it makes sense to exclude traffic from the status page itself.

Reference:
https://github.com/vozlt/nginx-module-vts#to-calculate-traffic-except-for-status-page

