### PR TITLE
Add avif support

### DIFF
--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -223,6 +223,9 @@ def post_pref(self, apt_packages, packages, upgrade=False):
                 WOTemplate.deploy(
                     self, '{0}/webp.conf'.format(ngxcnf),
                     'webp.mustache', data, overwrite=False)
+                WOTemplate.deploy(
+                    self, '{0}/avif.conf'.format(ngxcnf),
+                    'avif.mustache', data, overwrite=False)
 
                 WOTemplate.deploy(
                     self, '{0}/cloudflare.conf'.format(ngxcnf),

--- a/wo/cli/templates/avif.mustache
+++ b/wo/cli/templates/avif.mustache
@@ -1,0 +1,39 @@
+# avif NGINX CONFIGURATION - WordOps {{release}}
+# DO NOT MODIFY, ALL CHANGES WILL BE LOST AFTER AN WordOps (wo) UPDATE
+
+map $http_accept $avif_suffix_valid {
+   default 1;
+   "~*avif" 0;
+}
+
+map $realip_remote_addr $avif_suffix_cf {
+    default 0;
+    103.21.244.0/22         1;
+    103.22.200.0/22         1;
+    103.31.4.0/22           1;
+    104.16.0.0/12           1;
+    108.162.192.0/18        1;
+    131.0.72.0/22           1;
+    141.101.64.0/18         1;
+    162.158.0.0/15          1;
+    172.64.0.0/13           1;
+    173.245.48.0/20         1;
+    188.114.96.0/20         1;
+    190.93.240.0/20         1;
+    197.234.240.0/22        1;
+    198.41.128.0/17         1;
+    199.27.128.0/21         1;
+    2400:cb00::/32          1;
+    2405:8100::/32          1;
+    2405:b500::/32          1;
+    2606:4700::/32          1;
+    2803:f800::/32          1;
+    2a06:98c0::/29          1;
+    2c0f:f248::/32          1;
+
+}
+
+map $avif_suffix_cf$avif_suffix_valid $avif_suffix {
+    default "";
+    00 ".avif";
+}

--- a/wo/cli/templates/wpcommon.mustache
+++ b/wo/cli/templates/wpcommon.mustache
@@ -45,7 +45,7 @@ location /wp-content/uploads {
         access_log off;
         log_not_found off;
         expires max;
-        try_files $uri$webp_suffix $uri =404;
+        try_files $uri$avif_suffix $uri$webp_suffix $uri =404;
     }
     location ~* \.(php|gz|log|zip|tar|rar|xz)$ {
         #Prevent Direct Access Of PHP Files & Backups from Web Browsers


### PR DESCRIPTION
##### Summary

Add the [AVIF](https://aomediacodec.github.io/av1-avif/) support to Nginx stack. It should be simple as WebP integrate and need nothing special to config.

The type of AVIF image should be `octet-stream` then you're success as implement AVIF.

![Screen Shot 2020-09-15 at 08 26 45](https://user-images.githubusercontent.com/4527866/93154223-5206fc80-f72d-11ea-80fd-6a9c16e5502e.JPG)
