### PR TITLE
WordOps Maintenance Release v3.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### v3.9.x - [Unreleased]
 
+#### Changed
+
+- Use zstd instead of pigz for archive compression
+
+#### Fixed
+
+- fail2ban install without Nginx
+
 ### v3.12.2 - 2020-05-15
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### v3.9.x - [Unreleased]
 
+### v3.12.3 - 2020-10-13
+
 #### Added
 
 - Add avif (AV1 Image Format) support into Nginx ([PR #314](https://github.com/WordOps/WordOps/pull/314))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### v3.9.x - [Unreleased]
 
+#### Added
+
+- Add avif (AV1 Image Format) support into Nginx ([PR #314](https://github.com/WordOps/WordOps/pull/314))
+
 #### Changed
 
 - Use zstd instead of pigz for archive compression
+- Exclude Nginx_vts status page from traffic calculation ([PR #294](https://github.com/WordOps/WordOps/pull/294))
 
 #### Fixed
 
 - fail2ban install without Nginx
+- Grant MySQL permissions on all MySQL/MariaDB variant ([PR #285](https://github.com/WordOps/WordOps/pull/285))
 
 ### v3.12.2 - 2020-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - fail2ban install without Nginx
 - Grant MySQL permissions on all MySQL/MariaDB variant ([PR #285](https://github.com/WordOps/WordOps/pull/285))
+- PHP PECL extensions and PHP 8.0 issues
 
 ### v3.12.2 - 2020-05-15
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@
 
 #### Also compatible
 
-- Ubuntu 20.04 LTS (Focal)
 - Ubuntu 16.04 LTS (Xenial)
 - Debian 9 (Stretch)
 - Debian 10 (Buster)

--- a/install
+++ b/install
@@ -140,9 +140,9 @@ wo_init_variables() {
     readonly wo_install_log=/var/log/wo/install.log
     readonly TIME_FORMAT='%d-%b-%Y-%H%M%S'
     readonly TIME=$(date +"$TIME_FORMAT")
-    readonly NGINX_BACKUP_FILE="/var/lib/wo-backup/nginx-backup.$TIME.tar.gz"
-    readonly EE_BACKUP_FILE="/var/lib/wo-backup/ee-backup.$TIME.tar.gz"
-    readonly WO_BACKUP_FILE="/var/lib/wo-backup/wo-backup.$TIME.tar.gz"
+    readonly NGINX_BACKUP_FILE="/var/lib/wo-backup/nginx-backup.$TIME.tar.zst"
+    readonly EE_BACKUP_FILE="/var/lib/wo-backup/ee-backup.$TIME.tar.zst"
+    readonly WO_BACKUP_FILE="/var/lib/wo-backup/wo-backup.$TIME.tar.zst"
 
     if [ -x /usr/local/bin/ee ]; then
         ee_migration=1
@@ -209,13 +209,13 @@ wo_install_dep() {
         # install dependencies
         apt-get -option=Dpkg::options::=--force-confmiss --option=Dpkg::options::=--force-confold --assume-yes install \
             build-essential curl gzip python3-pip python3-apt python3-dev sqlite3 git tar software-properties-common pigz \
-            gnupg2 cron ccze rsync apt-transport-https tree haveged ufw unattended-upgrades tzdata ntp >/dev/null 2>&1
+            gnupg2 cron ccze rsync apt-transport-https tree haveged ufw unattended-upgrades tzdata ntp zstd >/dev/null 2>&1
         curl -sL https://download.opensuse.org/repositories/home:/virtubox:/WordOps/xUbuntu_18.04/Release.key | apt-key add -
     else
         # install dependencies
         apt-get -option=Dpkg::options::=--force-confmiss --option=Dpkg::options::=--force-confold --assume-yes install \
             build-essential curl gzip dirmngr sudo python3-pip python3-apt python3-dev ca-certificates sqlite3 git tar \
-            software-properties-common pigz apt-transport-https gnupg2 cron ccze rsync tree haveged ufw unattended-upgrades tzdata ntp >/dev/null 2>&1
+            software-properties-common pigz apt-transport-https gnupg2 cron ccze rsync tree haveged ufw unattended-upgrades tzdata ntp zstd >/dev/null 2>&1
         # add php repository gpg key
         [ -d /etc/apt/trusted.gpg.d ] && { wget -qO /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg; }
         # add nginx repository gpg key
@@ -224,7 +224,7 @@ wo_install_dep() {
     locale-gen en
     # enable unattended upgades
     if [ ! -f /etc/apt/apt.conf.d/20auto-upgrades ]; then
-        cp /usr/share/unattended-upgrades/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
+        cp -f /usr/share/unattended-upgrades/20auto-upgrades /etc/apt/apt.conf.d/20auto-upgrades
     fi
     # upgrade pip
     python3 -m pip install --upgrade pip
@@ -392,7 +392,7 @@ wo_install_acme_sh() {
 
     if [ -x "$HOME/.acme.sh/acme.sh" ]; then
         # backup acme.sh folder
-        /bin/tar -I pigz -cf /var/lib/wo-backup/acme.sh.tar.gz "$HOME/.acme.sh"
+        /bin/tar -I zstd -cf /var/lib/wo-backup/acme.sh.tar.zst "$HOME/.acme.sh"
         # rsync previous certificates to new acme.sh location
         /usr/bin/rsync -rltgoDpz --exclude="account.conf" \
             --exclude="acme.sh" \
@@ -468,7 +468,7 @@ wo_upgrade_nginx() {
     wo_distro_version=$(lsb_release -sc)
 
     if [ -d /var/lib/wo-backup/nginx ]; then
-        /bin/tar -I pigz "$NGINX_BACKUP_FILE" /var/lib/wo-backup/nginx
+        /bin/tar -I zstd "$NGINX_BACKUP_FILE" /var/lib/wo-backup/nginx
         rm -rf /var/lib/wo-backup/nginx
     fi
     # backup nginx conf
@@ -575,13 +575,13 @@ wo_backup_ee() {
     local BACKUP_EE=""
     [ -d /etc/nginx ] && { BACKUP_EE="$BACKUP_EE /etc/nginx"; }
     [ -d /etc/letsencrypt ] && { BACKUP_EE="$BACKUP_EE /etc/letsencrypt"; }
-    /bin/tar -I pigz -cf "$EE_BACKUP_FILE" /usr/local/bin/ee /usr/lib/ee/templates /etc/ee /var/lib/ee "$BACKUP_EE"
+    /bin/tar -I zstd -cf "$EE_BACKUP_FILE" /usr/local/bin/ee /usr/lib/ee/templates /etc/ee /var/lib/ee "$BACKUP_EE"
     return 0
 }
 
 wo_backup_wo() {
     if [ -d /etc/nginx ] && [ -d /etc/wo ] && [ -d /var/lib/wo ]; then
-        /bin/tar -I pigz -cf "$WO_BACKUP_FILE" /etc/nginx /etc/wo /var/lib/wo
+        /bin/tar -I zstd -cf "$WO_BACKUP_FILE" /etc/nginx /etc/wo /var/lib/wo
     fi
     return 0
 }

--- a/install
+++ b/install
@@ -9,7 +9,7 @@
 # -------------------------------------------------------------------------
 # wget -qO wo wops.cc && sudo -E bash wo
 # -------------------------------------------------------------------------
-# Version 3.12.2 - 2020-05-14
+# Version 3.12.3 - 2020-10-12
 # -------------------------------------------------------------------------
 
 # CONTENTS
@@ -699,6 +699,20 @@ wo_init() {
     wo_lib_echo "Welcome to WordOps install/update script ${wo_version_new}"
     echo ""
 
+}
+
+wo_php_fix() {
+    local php_versions="5.6 7.0 7.1 7.2 7.3 7.4"
+
+    apt-get autoremove --assume-yes --purge php8.0-* php-igbinary php-memcached php-msgpack php-redis php-imagick php-xdebug
+    for php_version in $php_versions; do
+        if [ -f "/usr/sbin/php-fpm$php_version" ]; then
+            local php_extensions="igbinary memcached msgpack redis imagick xdebug"
+            for php_ext in $php_extensions; do
+                apt-get -option=Dpkg::options::=--force-confmiss --option=Dpkg::options::=--force-confold --assume-yes install "php$php_version-$php_ext"
+            done
+        fi
+    done
 }
 
 ###

--- a/install
+++ b/install
@@ -745,6 +745,7 @@ else
         _run wo_clean
         _run wo_woconf
         _run wo_fix_kernel
+        _run wo_php_fix
         # 2 - Migration from EEv3
     else
         if [ -x /usr/local/bin/ee ]; then

--- a/install
+++ b/install
@@ -9,7 +9,7 @@
 # -------------------------------------------------------------------------
 # wget -qO wo wops.cc && sudo -E bash wo
 # -------------------------------------------------------------------------
-# Version 3.12.3 - 2020-10-12
+# Version 3.12.3 - 2020-10-13
 # -------------------------------------------------------------------------
 
 # CONTENTS
@@ -208,13 +208,13 @@ wo_install_dep() {
     if [ "$wo_linux_distro" == "Ubuntu" ]; then
         # install dependencies
         apt-get -option=Dpkg::options::=--force-confmiss --option=Dpkg::options::=--force-confold --assume-yes install \
-            build-essential curl gzip python3-pip python3-apt python3-dev sqlite3 git tar software-properties-common pigz \
+            build-essential curl gzip python3-pip python3-apt gcc python3-dev sqlite3 git tar software-properties-common pigz \
             gnupg2 cron ccze rsync apt-transport-https tree haveged ufw unattended-upgrades tzdata ntp zstd >/dev/null 2>&1
         curl -sL https://download.opensuse.org/repositories/home:/virtubox:/WordOps/xUbuntu_18.04/Release.key | apt-key add -
     else
         # install dependencies
         apt-get -option=Dpkg::options::=--force-confmiss --option=Dpkg::options::=--force-confold --assume-yes install \
-            build-essential curl gzip dirmngr sudo python3-pip python3-apt python3-dev ca-certificates sqlite3 git tar \
+            build-essential curl gzip dirmngr sudo python3-pip python3-apt gcc python3-dev ca-certificates sqlite3 git tar \
             software-properties-common pigz apt-transport-https gnupg2 cron ccze rsync tree haveged ufw unattended-upgrades tzdata ntp zstd >/dev/null 2>&1
         # add php repository gpg key
         [ -d /etc/apt/trusted.gpg.d ] && { wget -qO /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg; }

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if os.geteuid() == 0:
         os.makedirs('/var/lib/wo/tmp/')
 
 setup(name='wordops',
-      version='3.12.2',
+      version='3.12.3',
       description='An essential toolset that eases server administration',
       long_description=LONG,
       long_description_content_type='text/markdown',

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -314,24 +314,24 @@ echo -e '       wo info             '
 echo -e "${CGREEN}#############################################${CEND}"
 wo info
 
-echo -e "${CGREEN}#############################################${CEND}"
-echo -e '       wo site delete              '
-echo -e "${CGREEN}#############################################${CEND}"
-sites=$(wo site list 2>&1)
-for site in $sites; do
-    echo -ne "       deleting $site              [..]\r"
-    if {
-        wo site delete "$site" --force
-    } >>/var/log/wo/test.log; then
-        echo -ne "       deleting $site              [${CGREEN}OK${CEND}]\\r"
-        echo -ne '\n'
-    else
-        echo -e "       deleting $site              [${CRED}FAIL${CEND}]"
-        echo -ne '\n'
-        exit_script
+# echo -e "${CGREEN}#############################################${CEND}"
+# echo -e '       wo site delete              '
+# echo -e "${CGREEN}#############################################${CEND}"
+# sites=$(wo site list 2>&1)
+# for site in $sites; do
+#     echo -ne "       deleting $site              [..]\r"
+#     if {
+#         wo site delete "$site" --force
+#     } >>/var/log/wo/test.log; then
+#         echo -ne "       deleting $site              [${CGREEN}OK${CEND}]\\r"
+#         echo -ne '\n'
+#     else
+#         echo -e "       deleting $site              [${CRED}FAIL${CEND}]"
+#         echo -ne '\n'
+#         exit_script
 
-    fi
-done
+#     fi
+# done
 
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo stack purge              '

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -79,7 +79,7 @@ echo
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo site update --php74              '
 echo -e "${CGREEN}#############################################${CEND}"
-other_site_types='html mysql php72 php74 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir ngxblocker'
+other_site_types='mysql php72 php74 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir ngxblocker'
 for site in $other_site_types; do
     echo -ne "       Updating site to $site php74              [..]\r"
     if {
@@ -125,7 +125,7 @@ echo
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo site update --php72              '
 echo -e "${CGREEN}#############################################${CEND}"
-other_site_types='html mysql php72 php73 php74 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir ngxblocker'
+other_site_types='mysql php72 php73 php74 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir ngxblocker'
 for site in $other_site_types; do
     echo -ne "       Updating site to $site php72              [..]\r"
     if {
@@ -321,7 +321,7 @@ sites=$(wo site list 2>&1)
 for site in $sites; do
     echo -ne "       deleting $site              [..]\r"
     if {
-        wo site delete $site --force
+        wo site delete "$site" --force
     } >>/var/log/wo/test.log; then
         echo -ne "       deleting $site              [${CGREEN}OK${CEND}]\\r"
         echo -ne '\n'

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -73,7 +73,9 @@ echo
 wo site info php72.net
 echo
 echo
-
+wo site list
+echo
+echo
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo site update --php74              '
 echo -e "${CGREEN}#############################################${CEND}"

--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -219,7 +219,11 @@ def setupdatabase(self, data):
     Log.debug(self, "Setting up user privileges")
     try:
         WOMysql.execute(self,
-                        "grant select, insert, update, delete, create, drop, references, index, alter, create temporary tables, lock tables, execute, create view, show view, create routine, alter routine, event, trigger on `{0}`.* to `{1}`@`{2}`"
+                        "grant select, insert, update, delete, create, drop, "
+                        "references, index, alter, create temporary tables, "
+                        "lock tables, execute, create view, show view, "
+                        "create routine, alter routine, event, "
+                        "trigger on `{0}`.* to `{1}`@`{2}`"
                         .format(wo_db_name,
                                 wo_db_username, wo_mysql_grant_host))
     except StatementExcecutionError:

--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -810,8 +810,8 @@ def sitebackup(self, data):
         Log.info(self, 'Backing up database \t\t', end='')
         try:
             if not WOShellExec.cmd_exec(self, "mysqldump --single-transaction "
-                                        "{0} | pigz -9 -p\"$(nproc)\" "
-                                        "> {1}/{0}.gz"
+                                        "{0} | zstd -T0 -c"
+                                        "> {1}/{0}.zst"
                                         .format(data['wo_db_name'],
                                                 backup_path)):
                 Log.info(self,

--- a/wo/cli/templates/proftpd-tls.mustache
+++ b/wo/cli/templates/proftpd-tls.mustache
@@ -5,7 +5,7 @@ TLSRequired                   on
 TLSLog                        /var/log/proftpd/tls.log
 
 # intermediate configuration from ssl-config.mozilla.org
-TLSProtocol                   TLSv1.2 TLSv1.3
+TLSProtocol                   TLSv1.2
 TLSCipherSuite                ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384
 TLSServerCipherPreference     off
 TLSessionTickets              off

--- a/wo/core/mysql.py
+++ b/wo/core/mysql.py
@@ -112,7 +112,8 @@ class WOMysql():
                     "--single-transaction ".format(dbs),
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
                 p2 = subprocess.Popen(
-                    "/usr/bin/pigz -c > /var/lib/wo-backup/mysql/{0}{1}.sql.gz"
+                    "/usr/bin/zstd -T0 -c > "
+                    "/var/lib/wo-backup/mysql/{0}{1}.sql.zst"
                     .format(dbs, WOVar.wo_date), stdin=p1.stdout, shell=True)
                 # Allow p1 to receive a SIGPIPE if p2 exits
                 p1.stdout.close()

--- a/wo/core/variables.py
+++ b/wo/core/variables.py
@@ -137,7 +137,9 @@ class WOVar():
                  "readline", "common",
                  "cli", "mbstring", "intl",
                  "bcmath", "mysql", "opcache",
-                 "zip", "xml", "soap"]
+                 "zip", "xml", "soap", "memcached",
+                 "imagick", "igbinary", "msgpack",
+                 "redis", "xdebug"]
     wo_php72 = []
     for module in wo_module:
         wo_php72 = wo_php72 + ["php7.2-{0}".format(module)]
@@ -150,12 +152,7 @@ class WOVar():
     for module in wo_module:
         wo_php74 = wo_php74 + ["php7.4-{0}".format(module)]
 
-    if not wo_platform_codename == 'focal':
-        wo_php_extra = ["php-memcached", "php-imagick", "php-igbinary",
-                        "graphviz", "php-xdebug", "php-msgpack", "php-redis"]
-    else:
-        wo_php_extra = ["php-imagick", "php-igbinary",
-                        "graphviz", "php-xdebug", "php-msgpack", "php-redis"]
+    wo_php_extra = ["graphviz"]
 
     wo_mysql = ["mariadb-server", "percona-toolkit"]
     if wo_distro == 'raspbian':

--- a/wo/core/variables.py
+++ b/wo/core/variables.py
@@ -14,7 +14,7 @@ class WOVar():
     """Intialization of core variables"""
 
     # WordOps version
-    wo_version = "3.12.2"
+    wo_version = "3.12.3"
     # WordOps packages versions
     wo_wp_cli = "2.4.0"
     wo_adminer = "4.7.5"


### PR DESCRIPTION

#### Added

- Add avif (AV1 Image Format) support into Nginx ([PR #314](https://github.com/WordOps/WordOps/pull/314))

#### Changed

- Use zstd instead of pigz for archive compression
- Exclude Nginx_vts status page from traffic calculation ([PR #294](https://github.com/WordOps/WordOps/pull/294))

#### Fixed

- fail2ban install without Nginx
- Grant MySQL permissions on all MySQL/MariaDB variant ([PR #285](https://github.com/WordOps/WordOps/pull/285))
- PHP PECL extensions and PHP 8.0 issues