### PR TITLE
Update brotli.mustache

### DIFF
--- a/wo/cli/templates/brotli.mustache
+++ b/wo/cli/templates/brotli.mustache
@@ -4,8 +4,7 @@
 
 	brotli on;
 	brotli_static on;
-	brotli_buffers 16 8k;
-	brotli_comp_level 4;
+	brotli_comp_level 6;
 	brotli_types
 	application/atom+xml
 	application/geo+json


### PR DESCRIPTION
'brotli_comp_level 6' tends to be the most optimal and commonly used level.
'brotli_buffers' has been deprecated: https://github.com/google/ngx_brotli#brotli_buffers

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Additional Information
