### PR TITLE
Escaping of metacharacters in regex strings in wo/cli/templates/map-wp.mustache 

### DIFF
--- a/wo/cli/templates/map-wp.mustache
+++ b/wo/cli/templates/map-wp.mustache
@@ -36,14 +36,14 @@ map $request_uri $uri_no_cache {
     "~*/wp-comments-popup\.php" 1;
     "~*/wp-links-opml\.php" 1;
     "~*/xmlrpc\.php" 1;
-    "~*/edd-sl/*" 1;
+    "~*/edd-sl/.*" 1;
     "~*/add_to_cart/" 1;
     "~*/cart/" 1;
     "~*/account/" 1;
     "~*/my-account/" 1;
     "~*/checkout/" 1;
     "~*/addons/" 1;
-    "~*/wc-api/*" 1;
+    "~*/wc-api/.*" 1;
     "~*/logout/" 1;
     "~*/lost-password/" 1;
     "~*/panier/" 1;

--- a/wo/cli/templates/map-wp.mustache
+++ b/wo/cli/templates/map-wp.mustache
@@ -28,14 +28,14 @@ map $http_cookie $cookie_no_cache {
 map $request_uri $uri_no_cache {
     default 0;
     "~*/wp-admin/" 1;
-    "~*/wp-[a-zA-Z0-9-]+.php" 1;
+    "~*/wp-[a-zA-Z0-9-]+\.php" 1;
     "~*/feed/" 1;
-    "~*/index.php" 1;
-    "~*/[a-z0-9_-]+-sitemap([0-9]+)?.xml" 1;
-    "~*/sitemap(_index)?.xml" 1;
-    "~*/wp-comments-popup.php" 1;
-    "~*/wp-links-opml.php" 1;
-    "~*/xmlrpc.php" 1;
+    "~*/index\.php" 1;
+    "~*/[a-z0-9_-]+-sitemap([0-9]+)?\.xml" 1;
+    "~*/sitemap(_index)?\.xml" 1;
+    "~*/wp-comments-popup\.php" 1;
+    "~*/wp-links-opml\.php" 1;
+    "~*/xmlrpc\.php" 1;
     "~*/edd-sl/*" 1;
     "~*/add_to_cart/" 1;
     "~*/cart/" 1;


### PR DESCRIPTION
##### Summary

- Escape `.` characters in regex strings by putting a `\` in front of them (`\.`).
- Replace `*` characters in regex strings that should represent wildcards with `.*`.