### PR TITLE
create symlink for mariadb.service

### DIFF
--- a/wo/cli/plugins/stack_migrate.py
+++ b/wo/cli/plugins/stack_migrate.py
@@ -65,6 +65,8 @@ class WOStackMigrateController(CementBaseController):
             self, '/etc/mysql/my.cnf', '/etc/mysql/my.cnf.old')
         WOFileUtils.create_symlink(
             self, ['/etc/mysql/mariadb.cnf', '/etc/mysql/my.cnf'])
+        WOFileUtils.create_symlink(
+            self, ['/usr/lib/systemd/system/mariadb.service', '/etc/systemd/system/mysql.service'])
         WOShellExec.cmd_exec(self, 'systemctl daemon-reload')
         WOShellExec.cmd_exec(self, 'systemctl enable mariadb')
         post_pref(self, WOVar.wo_mysql, [])


### PR DESCRIPTION
migrating mysq to mariadb using command "wo stack migrate --mariadb --force" the symbolic link /etc/systemd/system/mysql.service is not created.
Symbolic link from /usr/lib/systemd/system/mariadb.service to /etc/systemd/system/mysql.service. So that the commands can perform actions on mysql / mariadb
wo stack status
wo stack restart
wo stack stop
...