### PR TITLE
Set cache expiry of css and js files to 1 year

### DIFF
--- a/wo/cli/templates/locations.mustache
+++ b/wo/cli/templates/locations.mustache
@@ -24,7 +24,7 @@ location ~* \.(?:css(\.map)?|js(\.map)?)$ {
     more_set_headers  "Cache-Control : public, no-transform";
     access_log off;
     log_not_found off;
-    expires 30d;
+    expires 1y;
 }
 # Security settings for better privacy
 # Deny hidden files

--- a/wo/cli/templates/wpcommon.mustache
+++ b/wo/cli/templates/wpcommon.mustache
@@ -75,7 +75,7 @@ location /wp-content/cache {
         more_set_headers 'Access-Control-Allow-Origin : *';
         access_log off;
         log_not_found off;
-        expires 30d;
+        expires 1y;
     }
     location ~ \.php$ {
         #Prevent Direct Access Of PHP Files From Web Browsers


### PR DESCRIPTION
Fixes #361

Currently cache expiry of css and js is set to 30d. However Google pagespeed expect it to be at least 1 year as per https://web.dev/uses-long-cache-ttl/.