### PR TITLE
Update Redis repo to Redis Labs team

### DIFF
--- a/wo/core/variables.py
+++ b/wo/core/variables.py
@@ -184,7 +184,7 @@ class WOVar():
                              codename=wo_platform_codename))
     if wo_distro == 'ubuntu':
         wo_php_repo = "ppa:ondrej/php"
-        wo_redis_repo = ("ppa:chris-lea/redis-server")
+        wo_redis_repo = ("ppa:redislabs/redis")
         wo_goaccess_repo = ("ppa:alex-p/goaccess")
 
     else:


### PR DESCRIPTION
Current PPA used by WordOps from chris-lea/redis-server is no longer maintained. Updating repo to redislabs/redis which maintain latest version of Redis.