### PR TITLE
Fix for nginx amplify agent

### DIFF
--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -809,13 +809,13 @@ def post_pref(self, apt_packages, packages, upgrade=False):
                 self, '/etc/php/7.4/fpm/php-fpm.conf',
                 'php-fpm.mustache', data)
 
-            data = dict(pool='www-php74', listen='php74-fpm.sock',
+            data = dict(pool='www-php74', listen='/var/run/php/php74-fpm.sock',
                         user='www-data',
                         group='www-data', listenuser='root',
                         listengroup='www-data', openbasedir=True)
             WOTemplate.deploy(self, '/etc/php/7.4/fpm/pool.d/www.conf',
                               'php-pool.mustache', data)
-            data = dict(pool='www-two-php74', listen='php74-two-fpm.sock',
+            data = dict(pool='www-two-php74', listen='/var/run/php/php74-two-fpm.sock',
                         user='www-data',
                         group='www-data', listenuser='root',
                         listengroup='www-data', openbasedir=True)

--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -811,13 +811,13 @@ def post_pref(self, apt_packages, packages, upgrade=False):
 
             data = dict(pool='www-php74', listen='/var/run/php/php74-fpm.sock',
                         user='www-data',
-                        group='www-data', listenuser='root',
+                        group='www-data', listenuser='www-data',
                         listengroup='www-data', openbasedir=True)
             WOTemplate.deploy(self, '/etc/php/7.4/fpm/pool.d/www.conf',
                               'php-pool.mustache', data)
             data = dict(pool='www-two-php74', listen='/var/run/php/php74-two-fpm.sock',
                         user='www-data',
-                        group='www-data', listenuser='root',
+                        group='www-data', listenuser='www-data',
                         listengroup='www-data', openbasedir=True)
             WOTemplate.deploy(self, '/etc/php/7.4/fpm/pool.d/www-two.conf',
                               'php-pool.mustache', data)

--- a/wo/cli/templates/22222.mustache
+++ b/wo/cli/templates/22222.mustache
@@ -4,7 +4,7 @@ server {
 
   listen {{port}} default_server ssl http2;
 
-  access_log   /var/log/nginx/22222.access.log rt_cache;
+  access_log   /var/log/nginx/22222.access.log main_ext;
   error_log    /var/log/nginx/22222.error.log warn;
 
   # Force HTTP to HTTPS

--- a/wo/cli/templates/22222.mustache
+++ b/wo/cli/templates/22222.mustache
@@ -5,7 +5,7 @@ server {
   listen {{port}} default_server ssl http2;
 
   access_log   /var/log/nginx/22222.access.log rt_cache;
-  error_log    /var/log/nginx/22222.error.log;
+  error_log    /var/log/nginx/22222.error.log warn;
 
   # Force HTTP to HTTPS
   error_page 497 =200 https://$host:{{port}}$request_uri;

--- a/wo/cli/templates/nginx-core.mustache
+++ b/wo/cli/templates/nginx-core.mustache
@@ -93,10 +93,15 @@ http {
 	error_log /var/log/nginx/error.log warn;
 
 	# Log format Settings
-	log_format rt_cache '$remote_addr $upstream_response_time $upstream_cache_status [$time_local] '
-	'$http_host "$request" $status $body_bytes_sent '
-	'"$http_referer" "$http_user_agent" "$server_protocol"';
-
+	log_format  main_ext  '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for" '
+                        '"$host" sn="$server_name" '
+                        'rt=$request_time '
+                        'ua="$upstream_addr" us="$upstream_status" '
+                        'ut="$upstream_response_time" ul="$upstream_response_length" '
+                        'cs=$upstream_cache_status' ;
+						
 	##
 	# Virtual Host Configs
 	##

--- a/wo/cli/templates/nginx-core.mustache
+++ b/wo/cli/templates/nginx-core.mustache
@@ -89,9 +89,6 @@ http {
 	# Logging Settings
 	##
 
-	access_log off;
-	error_log /var/log/nginx/error.log warn;
-
 	# Log format Settings
 	log_format rt_cache '$remote_addr $upstream_response_time $upstream_cache_status [$time_local] '
 	'$http_host "$request" $status $body_bytes_sent '
@@ -105,6 +102,9 @@ http {
                         'ua="$upstream_addr" us="$upstream_status" '
                         'ut="$upstream_response_time" ul="$upstream_response_length" '
                         'cs=$upstream_cache_status' ;
+
+	access_log /var/log/nginx/access.log main_ext;
+	error_log /var/log/nginx/error.log warn;
 
 	##
 	# Virtual Host Configs

--- a/wo/cli/templates/nginx-core.mustache
+++ b/wo/cli/templates/nginx-core.mustache
@@ -90,7 +90,7 @@ http {
 	##
 
 	access_log off;
-	error_log /var/log/nginx/error.log;
+	error_log /var/log/nginx/error.log warn;
 
 	# Log format Settings
 	log_format rt_cache '$remote_addr $upstream_response_time $upstream_cache_status [$time_local] '

--- a/wo/cli/templates/nginx-core.mustache
+++ b/wo/cli/templates/nginx-core.mustache
@@ -93,6 +93,10 @@ http {
 	error_log /var/log/nginx/error.log warn;
 
 	# Log format Settings
+	log_format rt_cache '$remote_addr $upstream_response_time $upstream_cache_status [$time_local] '
+	'$http_host "$request" $status $body_bytes_sent '
+	'"$http_referer" "$http_user_agent" "$server_protocol"';
+
 	log_format  main_ext  '$remote_addr - $remote_user [$time_local] "$request" '
                         '$status $body_bytes_sent "$http_referer" '
                         '"$http_user_agent" "$http_x_forwarded_for" '
@@ -101,7 +105,7 @@ http {
                         'ua="$upstream_addr" us="$upstream_status" '
                         'ut="$upstream_response_time" ul="$upstream_response_length" '
                         'cs=$upstream_cache_status' ;
-						
+
 	##
 	# Virtual Host Configs
 	##

--- a/wo/cli/templates/virtualconf.mustache
+++ b/wo/cli/templates/virtualconf.mustache
@@ -14,7 +14,7 @@ server {
     {{/multisite}}
 
     access_log /var/log/nginx/{{site_name}}.access.log {{^wpredis}}{{^static}}rt_cache{{/static}}{{/wpredis}}{{#wpredis}}rt_cache_redis{{/wpredis}};
-    error_log /var/log/nginx/{{site_name}}.error.log;
+    error_log /var/log/nginx/{{site_name}}.error.log warn;
 
     {{#proxy}}
     add_header X-Proxy-Cache $upstream_cache_status;

--- a/wo/cli/templates/virtualconf.mustache
+++ b/wo/cli/templates/virtualconf.mustache
@@ -13,7 +13,7 @@ server {
     #server_name_in_redirect off;
     {{/multisite}}
 
-    access_log /var/log/nginx/{{site_name}}.access.log {{^wpredis}}{{^static}}rt_cache{{/static}}{{/wpredis}}{{#wpredis}}rt_cache_redis{{/wpredis}};
+    access_log /var/log/nginx/{{site_name}}.access.log {{^wpredis}}{{^static}}main_ext{{/static}}{{/wpredis}}{{#wpredis}}rt_cache_redis{{/wpredis}};
     error_log /var/log/nginx/{{site_name}}.error.log warn;
 
     {{#proxy}}

--- a/wo/cli/templates/wo-plus.mustache
+++ b/wo/cli/templates/wo-plus.mustache
@@ -43,9 +43,6 @@ server_names_hash_bucket_size 16384;
 # Logging Settings
 ##
 
-access_log /var/log/nginx/access.log;
-error_log /var/log/nginx/error.log warn;
-
 # Log format Settings
 log_format rt_cache '$remote_addr $upstream_response_time $upstream_cache_status [$time_local] '
 '$http_host "$request" $status $body_bytes_sent '
@@ -59,6 +56,9 @@ log_format  main_ext  '$remote_addr - $remote_user [$time_local] "$request" '
                         'ua="$upstream_addr" us="$upstream_status" '
                         'ut="$upstream_response_time" ul="$upstream_response_length" '
                         'cs=$upstream_cache_status' ;
+
+access_log /var/log/nginx/access.log main_ext;
+error_log /var/log/nginx/error.log warn;
 
 ##
 # Gzip Settings

--- a/wo/cli/templates/wo-plus.mustache
+++ b/wo/cli/templates/wo-plus.mustache
@@ -44,7 +44,7 @@ server_names_hash_bucket_size 16384;
 ##
 
 access_log /var/log/nginx/access.log;
-error_log /var/log/nginx/error.log;
+error_log /var/log/nginx/error.log warn;
 
 # Log format Settings
 log_format rt_cache '$remote_addr $upstream_response_time $upstream_cache_status [$time_local] '

--- a/wo/cli/templates/wo-plus.mustache
+++ b/wo/cli/templates/wo-plus.mustache
@@ -49,7 +49,16 @@ error_log /var/log/nginx/error.log warn;
 # Log format Settings
 log_format rt_cache '$remote_addr $upstream_response_time $upstream_cache_status [$time_local] '
 '$http_host "$request" $status $body_bytes_sent '
-'"$http_referer" "$http_user_agent" "$request_body"';
+'"$http_referer" "$http_user_agent" "$server_protocol"';
+
+log_format  main_ext  '$remote_addr - $remote_user [$time_local] "$request" '
+                        '$status $body_bytes_sent "$http_referer" '
+                        '"$http_user_agent" "$http_x_forwarded_for" '
+                        '"$host" sn="$server_name" '
+                        'rt=$request_time '
+                        'ua="$upstream_addr" us="$upstream_status" '
+                        'ut="$upstream_response_time" ul="$upstream_response_length" '
+                        'cs=$upstream_cache_status' ;
 
 ##
 # Gzip Settings


### PR DESCRIPTION
Nginx amplify agent requires certain configuration to run with default settings as per [documentation](https://github.com/nginxinc/nginx-amplify-doc/blob/master/amplify-guide.md)
- Use absolute path to php socket for listen, instead of relative path
- Use www-data as user for listenuser, instead of root user
- Set error log level to warn
- Use additional metrics for access log. Changed access log format from rt_cache to main_ext
- Keep rt_cache log format as a fallback for already setup websites
- Enable access log with additional metrics with main_ext log format

**To Do:**
- Change access log format for rt_cache_redis also, similar to rt_cache