### PR TITLE
fix acme.sh to use letsencrypt by default in new installs

### DIFF
--- a/install
+++ b/install
@@ -421,6 +421,7 @@ wo_install_acme_sh() {
         /etc/letsencrypt/acme.sh --config-home '/etc/letsencrypt/config' --upgrade --auto-upgrade
         /etc/letsencrypt/acme.sh --config-home '/etc/letsencrypt/config' --uninstall-cronjob
         /etc/letsencrypt/acme.sh --config-home '/etc/letsencrypt/config' --install-cronjob
+        /etc/letsencrypt/acme.sh --set-default-ca --server letsencrypt
     fi
 
 }


### PR DESCRIPTION
update install script so that acme.sh will use LetsEncrypt instead of ZeroSSL when the `--letsencrypt` parameter is used.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #387. Updates install script so that acme.sh will use LetsEncrypt instead of ZeroSSL in new installs.

##### Additional Information
Current behaviour is for acme.sh to use ZeroSSL as default CA when the `--letsncrypt` parameter is used. This is confusing and unintuitive for users. Adding this line to the install script ensures that when the WordOps user enters `--letsencrypt`, acme.sh will actually use LetsEncrypt.