### PR TITLE
Cache exception for PWA Service Worker

### DIFF
--- a/wo/cli/templates/map-wp.mustache
+++ b/wo/cli/templates/map-wp.mustache
@@ -51,6 +51,7 @@ map $request_uri $uri_no_cache {
     "~*/embed" 1;
     "~*/commande/" 1;
     "~*/resetpass/" 1;
+    "~*/wp.serviceworker" 1;
 }
 # mobile_prefix needed for WP-Rocket
 map $http_user_agent $mobile_prefix {


### PR DESCRIPTION
##### Summary
Exclude PWA Service Worker file from cache. It's located at /wp.serviceworker
