### PR TITLE
fix: Support arm64 architecture (e.g. AWS Graviton2)

### DIFF
--- a/wo/core/variables.py
+++ b/wo/core/variables.py
@@ -177,7 +177,7 @@ class WOVar():
     wo_ubuntu_backports = 'ppa:jonathonf/backports'
 
     # APT repositories
-    wo_mysql_repo = ("deb [arch=amd64,ppc64el] "
+    wo_mysql_repo = ("deb [arch=amd64,arm64,ppc64el] "
                      "http://mariadb.mirrors.ovh.net/MariaDB/repo/"
                      "10.5/{distro} {codename} main"
                      .format(distro=wo_distro,


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

Support arm64 architecture

##### Additional Information

Enables mysqlclient / mariadb-client to be installed in e.g. AWS Graviton2 instances.