### PR TITLE
#420: No error treatment to /opt/cf-update.sh

### DIFF
--- a/wo/cli/templates/cf-update.mustache
+++ b/wo/cli/templates/cf-update.mustache
@@ -62,7 +62,9 @@ if [ -d /etc/nginx/conf.d ]; then
             echo "set_real_ip_from ${ip};" >> "${cfConf}"
         done
 
-        service nginx reload
+        echo 'real_ip_header CF-Connecting-IP;' >> "${cfConf}"
+
+        nginx -t && service nginx reload
     else
         echo "There are some errors in the IP blocks" >&2
         exit 1


### PR DESCRIPTION
In the previous commit I forgot to add the `real_ip_header CF-Connecting-IP` directive to the generated configuration file.

Also, I added a `nginx -t` before the `service nginx reload`.
