### PR TITLE
fix obsolete warnings logged

### DIFF
--- a/wo/cli/templates/tweaks.mustache
+++ b/wo/cli/templates/tweaks.mustache
@@ -1,8 +1,8 @@
 # NGINX Tweaks  - WordOps {{release}}
 	directio 4m;
 	directio_alignment 512;
-	http2_max_field_size 16k;
-	http2_max_header_size 32k;
+	#http2_max_field_size 16k;
+	#http2_max_header_size 32k;
 
 	large_client_header_buffers 8 64k;
 


### PR DESCRIPTION
Nginx 1.19.7+ Deprecated HTTP/2 variables.

If you're using these deprecated HTTP/2 variables in Nginx 1.19.7+ vhosts, on Nginx service restarts or Nginx config checks (nginx -t), you'll get Nginx warning messages as such but the Nginx service will still start and run Nginx server fine. Example warning message:

```
root@wooserv:~# nginx -t
nginx: [warn] the "http2_max_field_size" directive is obsolete, use the "large_client_header_buffers" directive instead in /etc/nginx/conf.d/tweaks.conf:4
nginx: [warn] the "http2_max_header_size" directive is obsolete, use the "large_client_header_buffers" directive instead in /etc/nginx/conf.d/tweaks.conf:5
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```


**Details:** http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2_max_field_size