### PR TITLE
Update stack_pref.py

### DIFF
--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -2007,6 +2007,7 @@ def pre_stack(self):
             # use tcp_bbr congestion algorithm only on new kernels
             if (WOVar.wo_platform_codename == 'bionic' or
                 WOVar.wo_platform_codename == 'focal' or
+                WOVar.wo_platform_codename == 'jammy' or
                     WOVar.wo_platform_codename == 'buster'):
                 try:
                     WOShellExec.cmd_exec(


### PR DESCRIPTION
- use tcp_bbr congestion algorithm only on new kernels [ Support Ubuntu 22.04 Jammy ]

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Additional Information
