### PR TITLE
Update acme.py

### DIFF
--- a/wo/core/acme.py
+++ b/wo/core/acme.py
@@ -276,4 +276,5 @@ class WOAcme:
                 ssl_conf_file.write("ssl_certificate "
                                     "/var/www/22222/cert/22222.crt;\n"
                                     "ssl_certificate_key "
-                                    "/var/www/22222/cert/22222.key;\n")
+                                    "/var/www/22222/cert/22222.key;\n"
+                                    "ssl_stapling off;\n")


### PR DESCRIPTION
Fix: nginx: [warn] "ssl_stapling" ignored, issuer certificate not found for certificate "/var/www/22222/cert/22222.crt"
