### PR TITLE
Update stack_pref.py

### DIFF
--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -398,7 +398,8 @@ def post_pref(self, apt_packages, packages, upgrade=False):
                     php_file.write("ssl_certificate "
                                    "/var/www/22222/cert/22222.crt;\n"
                                    "ssl_certificate_key "
-                                   "/var/www/22222/cert/22222.key;\n")
+                                   "/var/www/22222/cert/22222.key;\n"
+                                   "ssl_stapling off;\n")
 
                 server_ip = requests.get('http://v4.wordops.eu')
 


### PR DESCRIPTION
FIX: nginx: [warn] "ssl_stapling" ignored, issuer certificate not found for certificate "/var/www/22222/cert/22222.crt"

