### PR TITLE
remove the -crypt option

### DIFF
--- a/wo/cli/plugins/secure.py
+++ b/wo/cli/plugins/secure.py
@@ -83,11 +83,11 @@ class WOSecureController(CementBaseController):
             if password == "":
                 pargs.user_pass = passwd
         Log.debug(self, "printf username:"
-                  "$(openssl passwd -crypt "
+                  "$(openssl passwd -apr1 "
                   "password 2> /dev/null)\n\""
                   "> /etc/nginx/htpasswd-wo 2>/dev/null")
         WOShellExec.cmd_exec(self, "printf \"{username}:"
-                             "$(openssl passwd -crypt "
+                             "$(openssl passwd -apr1 "
                              "{password} 2> /dev/null)\n\""
                              "> /etc/nginx/htpasswd-wo 2>/dev/null"
                              .format(username=pargs.user_input,

--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -324,7 +324,7 @@ def post_pref(self, apt_packages, packages, upgrade=False):
                 try:
                     WOShellExec.cmd_exec(
                         self, "printf \"WordOps:"
-                        "$(openssl passwd -crypt "
+                        "$(openssl passwd -apr1 "
                         "{password} 2> /dev/null)\n\""
                         "> /etc/nginx/htpasswd-wo "
                         "2>/dev/null"


### PR DESCRIPTION
* The -crypt option to the passwd command line tool has been removed. [Reference](https://github.com/openssl/openssl/commit/c87a7f31a3db97376d764583ad5ee4a76db2cbef#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R26).

* Using option -apr1 is more securely