### PR TITLE
Update nginx-core.mustache

### DIFF
--- a/wo/cli/templates/nginx-core.mustache
+++ b/wo/cli/templates/nginx-core.mustache
@@ -63,13 +63,10 @@ http {
 	ssl_protocols TLSv1.2 TLSv1.3;
 	ssl_ecdh_curve X25519:P-521:P-384:P-256;
 
-
 	# Common security headers
 	more_set_headers "X-Frame-Options : SAMEORIGIN";
-	more_set_headers "X-Xss-Protection : 1; mode=block";
 	more_set_headers "X-Content-Type-Options : nosniff";
 	more_set_headers "Referrer-Policy : strict-origin-when-cross-origin";
-	more_set_headers "X-Download-Options : noopen";
 
 	# oscp settings
 	resolver 8.8.8.8 1.1.1.1 8.8.4.4 1.0.0.1 valid=300s;


### PR DESCRIPTION
# X-XSS-Protection

Even though this feature can protect users of older web browsers that don't yet support CSP, in some cases, XSS protection can create XSS vulnerabilities in otherwise safe websites.

Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection https://thexssrat.medium.com/x-xss-protection-headers-protection-or-vulnerability-bc7213951320

Chrome has removed their XSS Auditor
Firefox has not, and will not implement X-XSS-Protection Edge has retired its XSS filter.

# X-Download-Options

Microsoft announced the retirement of Internet Explorer and it's rendered inoperable since June 15, 2022. So, we may safely remove this IE 8 specific HTTP Header too.

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Additional Information
