### PR TITLE
fix prefetch-proxy configuration

### DIFF
--- a/wo/cli/templates/locations.mustache
+++ b/wo/cli/templates/locations.mustache
@@ -41,7 +41,7 @@ location /.well-known/acme-challenge/ {
 # https://developer.chrome.com/blog/private-prefetch-proxy/
 location /.well-known/traffic-advice {
    types { } default_type "application/trafficadvice+json; charset=utf-8";
-   return 200 "[\{\n  \"user_agent\": \"prefetch-proxy\",\n  \"google_prefetch_proxy_eap\": \{\n    \"fraction\": 1.0\n  \}\n\}]";
+   return 200 "[{\n  \"user_agent\": \"prefetch-proxy\",\n  \"google_prefetch_proxy_eap\": {\n    \"fraction\": 1.0\n  }\n}]";
    allow all;
 }
 # Return 403 forbidden for readme.(txt|html) or license.(txt|html) or example.(txt|html) or other common git repository files


### PR DESCRIPTION
Seems there is an issue with these changes. This is what the output of `https://www.example.com/.well-known/traffic-advice` looks like with WO 3.15.3 :
```
[\{
 "user_agent": "prefetch-proxy",
 "google_prefetch_proxy_eap": \{
 "fraction": 1.0
 \}
\}]
```
**Here is the expected output for a valid configuration**:
```
[{
 "user_agent": "prefetch-proxy",
 "google_prefetch_proxy_eap": {
 "fraction": 1.0
 }
}]
```

<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary

##### Additional Information
