### PR TITLE
Fix wrong else statements in stack_services.py

### DIFF
--- a/wo/cli/plugins/stack_services.py
+++ b/wo/cli/plugins/stack_services.py
@@ -286,15 +286,15 @@ class WOStackStatusController(CementBaseController):
             if os.path.exists('{0}'.format(wo_system) + 'php7.4-fpm.service'):
                 services = services + ['php7.4-fpm']
             else:
-                Log.info(self, "PHP8.0-FPM is not installed")
+                Log.info(self, "PHP7.4-FPM is not installed")
             if os.path.exists('{0}'.format(wo_system) + 'php8.0-fpm.service'):
                 services = services + ['php8.0-fpm']
             else:
-                Log.info(self, "PHP8.1-FPM is not installed")
+                Log.info(self, "PHP8.0-FPM is not installed")
             if os.path.exists('{0}'.format(wo_system) + 'php8.1-fpm.service'):
                 services = services + ['php8.1-fpm']
             else:
-                Log.info(self, "PHP7.4-FPM is not installed")
+                Log.info(self, "PHP8.1-FPM is not installed")
 
         if pargs.php72:
             if os.path.exists('{0}'.format(wo_system) + 'php7.2-fpm.service'):


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
* Fix wrong else statements in stack_services.py.

##### Additional Information
I've only installed PHP 8.0 and I see (`PHP8.0-FPM is not installed` ???):
```
PHP7.2-FPM is not installed
PHP7.3-FPM is not installed
PHP8.0-FPM is not installed
PHP7.4-FPM is not installed
Testing Nginx configuration     [OK]
Restarting Nginx                [OK]
Restarting php8.0-fpm           [OK]
Restarting mariadb              [OK]
Restarting netdata              [OK]
```