### PR TITLE
Update memory limit to WooCommerce recommended requirements

### DIFF
--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -376,8 +376,8 @@ def setupwordpress(self, data, vhostonly=False):
     # set all wp-config.php variables
     wp_conf_variables = [
         ['WP_REDIS_PREFIX', '{0}:'.format(wo_domain_name)],
-        ['WP_MEMORY_LIMIT', '128M'],
-        ['WP_MAX_MEMORY_LIMIT', '256M'],
+        ['WP_MEMORY_LIMIT', '256M'],
+        ['WP_MAX_MEMORY_LIMIT', '512M'],
         ['CONCATENATE_SCRIPTS', 'false'],
         ['WP_POST_REVISIONS', '10'],
         ['MEDIA_TRASH', 'true'],


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and degin decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Set WP_MEMORY_LIMIT to 256M as per WooCommerce recommended requirements: WordPress memory limit of 256 MB or greater. Also changed WP_MAX_MEMORY_LIMIT to 512M as double of WP_MEMORY_LIMIT.
