### PR TITLE
bug fix: close file after reading

### DIFF
--- a/wo/core/sendmail.py
+++ b/wo/core/sendmail.py
@@ -17,9 +17,10 @@ def WOSendMail(send_from, send_to, subject, text, files, server="localhost",
 
     msg.attach(MIMEText(text))
 
-    for f in files:
+    for file in files:
         part = MIMEBase('application', "octet-stream")
-        part.set_payload(open(f, "rb").read())
+        with open(file, 'rb') as f:
+            part.set_payload(f.read())
         encoders.encode_base64(part)
         part.add_header('Content-Disposition', 'attachment; filename="{0}"'
                         .format(os.path.basename(f)))


### PR DESCRIPTION
##### Summary
When sending an email, multiple files are opened and read but never closed. While this will be GCed on exit, it is always a good idea to close open files.

##### Additional Information
The code of the `WOSendMail` function is similar to the code in this [answer](https://stackoverflow.com/a/16509278) and the bug is fixed in the second version of the answer.