### PR TITLE
Do not cache requests with Authorization header set

### DIFF
--- a/wo/cli/templates/map-wp.mustache
+++ b/wo/cli/templates/map-wp.mustache
@@ -7,6 +7,12 @@ map $http_x_requested_with $http_request_no_cache {
     XMLHttpRequest 1;
 }
 
+# do not cache requests with Authorization: header set
+map $http_authorization $http_auth_no_cache {
+    default 1;
+    "" 0;
+}
+
 # do not cache requests on cookies
 map $http_cookie $cookie_no_cache {
     default 0;
@@ -81,9 +87,9 @@ map $is_args_no_cache$args_to_cache $query_no_cache {
 }
 
 # if all previous check are passed, $skip_cache = 0
-map $http_request_no_cache$cookie_no_cache$uri_no_cache$query_no_cache $skip_cache {
+map $http_request_no_cache$http_auth_no_cache$cookie_no_cache$uri_no_cache$query_no_cache $skip_cache {
     default 1;
-    0000 0;
+    00000 0;
 }
 
 # map $skip_cache with $cache_uri for --wpsc --wpce & --wprocket stack


### PR DESCRIPTION
### Summary

The full-page caching set up by WordOps will incorrectly cache some authenticated responses to the WordPress REST API.

### Additional Information

#### Steps to reproduce

1. Set up a WordOps site with the `--wpredis` option (and perhaps others) to enable full-page caching. Let's say it's `https://yoursite.com`.
2. Log in to wp-admin as an administrator user (let's say the username is `administrator`).
3. Go to Users > Profile and create a new application password under the Application Passwords section. Let's say it's `abcd efgh ijkl mnop qrst uvwx`.
4. Create a new post from the wp-admin interface. Save it as a draft; do not publish it. Record its ID (let's say it's `999`).
5. Generate a base64 authentication string in the terminal using the values from the previous steps: `echo -n 'administrator:abcd efgh ijkl mnop qrst uvwx' | base64`. Record the result (in this case `YWRtaW5pc3RyYXRvcjphYmNkIGVmZ2ggaWprbCBtbm9wIHFyc3QgdXZ3eA==`).
6. Make a request to your draft post in the WP REST API using the terminal: `curl -v https://yoursite.com/wp-json/wp/v2/posts/999`. You should see an error message with `rest_forbidden` code.
7. Now make the same request with authentication: `curl -v https://yoursite.com/wp-json/wp/v2/posts/999 -H 'Authorization: Basic YWRtaW5pc3RyYXRvcjphYmNkIGVmZ2ggaWprbCBtbm9wIHFyc3QgdXZ3eA==`. You should see a whole bunch of data about the post, which is fine. **The header information above should indicate `X-SRCache-Store-Status: STORE` which is a problem.**
8. Repeat the request from step 6. **You should see the same post data, which has been returned from the cache to an unauthenticated user.**

#### Proposed Solution

Prevent any requests containing a non-empty `Authorization:` header from being cached.

#### Alternatives

I considered disabling caching for the WP REST API instead. I am not sure if this would be desired or not. Some sites may benefit from the speed-up of having API requests cached, but also, API requests are currently not invalidated correctly when posts are updated (and this is generally a hard problem to solve).