### PR TITLE
#587: fix missing braces on force-ssl.mustache

### DIFF
--- a/wo/cli/templates/force-ssl.mustache
+++ b/wo/cli/templates/force-ssl.mustache
@@ -1,6 +1,6 @@
 server {
         listen 80;
         listen [::]:80;
-        server_name {domains};
+        server_name {{domains}};
         return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
Just fix missing braces on force-ssl.mustache causing adding SSL to websites to fail on WO 3.19.
