### PR TITLE
Create subsite

### DIFF
--- a/config/bash_completion.d/wo_auto.rc
+++ b/config/bash_completion.d/wo_auto.rc
@@ -159,13 +159,13 @@ _wo_complete()
 
             "create")
                 COMPREPLY=( $(compgen \
-                                    -W "--user --pass --email --html --php --php72 --php73 --php74 --php80 --php81 --php82 --php83  --mysql --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --proxy= --alias --subsite --wpredis --wprocket --wpce -le --letsencrypt  --letsencrypt=wildcard -le=wildcard --dns --dns=dns_cf --dns=dns_dgon" \
+                                    -W "--user --pass --email --html --php --php72 --php73 --php74 --php80 --php81 --php82 --php83  --mysql --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --proxy= --alias --subsiteof --wpredis --wprocket --wpce -le --letsencrypt  --letsencrypt=wildcard -le=wildcard --dns --dns=dns_cf --dns=dns_dgon" \
                                  -- $cur) )
                 ;;
 
             "update")
                 COMPREPLY=( $(compgen \
-                                    -W "--password --php --php72 --php73 --php74 --php80 --php81 --php82 --php83  --mysql --wp --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce --alias --subsite -le -le=off --letsencrypt --letsencrypt=off --letsencrypt=clean -le=wildcard -le=clean --dns --dns=dns_cf --dns=dns_dgon --ngxblocker --ngxblocker=off" \
+                                    -W "--password --php --php72 --php73 --php74 --php80 --php81 --php82 --php83  --mysql --wp --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce --alias --subsiteof -le -le=off --letsencrypt --letsencrypt=off --letsencrypt=clean -le=wildcard -le=clean --dns --dns=dns_cf --dns=dns_dgon --ngxblocker --ngxblocker=off" \
                                  -- $cur) )
                 ;;
             "delete")

--- a/config/bash_completion.d/wo_auto.rc
+++ b/config/bash_completion.d/wo_auto.rc
@@ -159,13 +159,13 @@ _wo_complete()
 
             "create")
                 COMPREPLY=( $(compgen \
-                                    -W "--user --pass --email --html --php --php72 --php73 --php74 --php80 --php81 --php82 --php83  --mysql --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --proxy= --alias --wpredis --wprocket --wpce -le --letsencrypt  --letsencrypt=wildcard -le=wildcard --dns --dns=dns_cf --dns=dns_dgon" \
+                                    -W "--user --pass --email --html --php --php72 --php73 --php74 --php80 --php81 --php82 --php83  --mysql --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --proxy= --alias --subsite --wpredis --wprocket --wpce -le --letsencrypt  --letsencrypt=wildcard -le=wildcard --dns --dns=dns_cf --dns=dns_dgon" \
                                  -- $cur) )
                 ;;
 
             "update")
                 COMPREPLY=( $(compgen \
-                                    -W "--password --php --php72 --php73 --php74 --php80 --php81 --php82 --php83  --mysql --wp --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce --alias -le -le=off --letsencrypt --letsencrypt=off --letsencrypt=clean -le=wildcard -le=clean --dns --dns=dns_cf --dns=dns_dgon --ngxblocker --ngxblocker=off" \
+                                    -W "--password --php --php72 --php73 --php74 --php80 --php81 --php82 --php83  --mysql --wp --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce --alias --subsite -le -le=off --letsencrypt --letsencrypt=off --letsencrypt=clean -le=wildcard -le=clean --dns --dns=dns_cf --dns=dns_dgon --ngxblocker --ngxblocker=off" \
                                  -- $cur) )
                 ;;
             "delete")

--- a/wo/cli/plugins/site_create.py
+++ b/wo/cli/plugins/site_create.py
@@ -127,7 +127,7 @@ class WOSiteCreateController(CementBaseController):
             proxyinfo = proxyinfo.split(':')
             host = proxyinfo[0].strip()
             port = '80' if len(proxyinfo) < 2 else proxyinfo[1].strip()
-        elif stype is None and not pargs.proxy and not pargs.alias and not pargs.subsiteofof:
+        elif stype is None and not pargs.proxy and not pargs.alias and not pargs.subsiteof:
             stype, cache = 'html', 'basic'
         elif stype is None and pargs.alias:
             stype, cache = 'alias', ''

--- a/wo/cli/plugins/site_create.py
+++ b/wo/cli/plugins/site_create.py
@@ -7,7 +7,7 @@ from wo.cli.plugins.site_functions import (
     doCleanupAction, setupdatabase, setupwordpress, setwebrootpermissions,
     display_cache_settings, copyWildcardCert)
 from wo.cli.plugins.sitedb import (addNewSite, deleteSiteInfo,
-                                   updateSiteInfo)
+                                   updateSiteInfo, getSiteInfo)
 from wo.core.acme import WOAcme
 from wo.core.domainvalidate import WODomain
 from wo.core.git import WOGit
@@ -196,14 +196,18 @@ class WOSiteCreateController(CementBaseController):
             data['basic'] = True
 
         if stype == 'subsite':
+            # Get parent site data
+            data = getSiteInfo(self, subsite_name)
             data = dict(
                 site_name=wo_domain, www_domain=wo_www_domain,
                 static=True, basic=False, wp=False,
                 wpfc=False, wpsc=False, wprocket=False, wpce=False,
                 multisite=False, wpsubdir=False, webroot=wo_site_webroot)
+            data["site_name"] = wo_domain
+            data["www_domain"] = wo_www_domain
             data['subsite'] = True
             data['subsite_name'] = subsite_name
-            data['basic'] = True
+
 
         if (pargs.php72 or pargs.php73 or pargs.php74 or
                 pargs.php80 or pargs.php81 or pargs.php82 or pargs.php83):

--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -67,11 +67,6 @@ def setupdomain(self, data):
     wo_domain_name = data['site_name']
     wo_site_webroot = data['webroot']
 
-    if 'subsite' in data.keys() and data['subsite']:
-        wo_parent_site = data["subsiteof_name"]
-        wo_parent_info = getSiteInfo(wo_parent_site)
-        data["webroot"] = wo_parent_info["webroot"]
-
     # Check if nginx configuration already exists
     # if os.path.isfile('/etc/nginx/sites-available/{0}'
     #                   .format(wo_domain_name)):

--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -68,7 +68,7 @@ def setupdomain(self, data):
     wo_site_webroot = data['webroot']
 
     if 'subsite' in data.keys() and data['subsite']:
-        wo_parent_site = data["subsite_name"]
+        wo_parent_site = data["subsiteof_name"]
         wo_parent_info = getSiteInfo(wo_parent_site)
         data["webroot"] = wo_parent_info["webroot"]
 

--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -67,6 +67,11 @@ def setupdomain(self, data):
     wo_domain_name = data['site_name']
     wo_site_webroot = data['webroot']
 
+    if 'subsite' in data.keys() and data['subsite']:
+        wo_parent_site = data["subsite_name"]
+        wo_parent_info = getSiteInfo(wo_parent_site)
+        data["webroot"] = wo_parent_info["webroot"]
+
     # Check if nginx configuration already exists
     # if os.path.isfile('/etc/nginx/sites-available/{0}'
     #                   .format(wo_domain_name)):

--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -836,7 +836,7 @@ def site_package_check(self, stype):
     stack.app = self.app
     pargs = self.app.pargs
     if stype in ['html', 'proxy', 'php', 'php72', 'mysql', 'wp', 'wpsubdir',
-                 'wpsubdomain', 'php73', 'php74', 'php80', 'php81', 'php82', 'php83', 'alias']:
+                 'wpsubdomain', 'php73', 'php74', 'php80', 'php81', 'php82', 'php83', 'alias', 'subsite']:
         Log.debug(self, "Setting apt_packages variable for Nginx")
 
         # Check if server has nginx-custom package

--- a/wo/cli/plugins/site_update.py
+++ b/wo/cli/plugins/site_update.py
@@ -164,7 +164,7 @@ class WOSiteUpdateController(CementBaseController):
             if not subsiteof_name:
                 Log.error(self, "Please provide multisite parent name")
         elif stype is None and not (pargs.proxy or
-                                    pargs.letsencrypt or 
+                                    pargs.letsencrypt or
                                     pargs.alias or
                                     pargs.subsiteof):
             stype, cache = 'html', 'basic'
@@ -587,7 +587,7 @@ class WOSiteUpdateController(CementBaseController):
             Log.info(self, "Successfully updated site"
                      " http://{0}".format(wo_domain))
             return 0
-        
+
         if 'subsite' in data.keys() and data['subsite']:
             updateSiteInfo(self, wo_domain, stype=stype, cache=cache,
                            ssl=(bool(check_site.is_ssl)))

--- a/wo/cli/plugins/site_update.py
+++ b/wo/cli/plugins/site_update.py
@@ -64,6 +64,9 @@ class WOSiteUpdateController(CementBaseController):
             (['--alias'],
                 dict(help="domain name to redirect to",
                      action='store', nargs='?')),
+            (['--subsiteof'],
+                dict(help="create a subsite of a multisite install",
+                    action='store', nargs='?')),
             (['-le', '--letsencrypt'],
                 dict(help="configure letsencrypt ssl for the site",
                      action='store' or 'store_const',
@@ -155,11 +158,18 @@ class WOSiteUpdateController(CementBaseController):
             alias_name = pargs.alias.strip()
             if not alias_name:
                 Log.error(self, "Please provide alias name")
+        elif stype is None and pargs.subsiteof:
+            stype, cache = 'subsite', ''
+            subsiteof_name = pargs.subsiteof.strip()
+            if not subsiteof_name:
+                Log.error(self, "Please provide multisite parent name")
         elif stype is None and not (pargs.proxy or
-                                    pargs.letsencrypt or pargs.alias):
+                                    pargs.letsencrypt or 
+                                    pargs.alias or
+                                    pargs.subsiteof):
             stype, cache = 'html', 'basic'
-        elif stype and (pargs.proxy or pargs.alias):
-            Log.error(self, "--proxy/alias can not be used with other site types")
+        elif stype and (pargs.proxy or pargs.alias or pargs.subsiteof):
+            Log.error(self, "--proxy/alias/subsiteof can not be used with other site types")
 
         if not pargs.site_name:
             try:
@@ -292,6 +302,35 @@ class WOSiteUpdateController(CementBaseController):
             data['currcachetype'] = oldcachetype
             data['alias'] = True
             data['alias_name'] = alias_name
+
+        if stype == 'subsite':
+            # Get parent site data
+            parent_site_info = getSiteInfo(self, subsiteof_name)
+            if not parent_site_info:
+                Log.error(self, "Parent site {0} does not exist"
+                          .format(subsiteof_name))
+            if not parent_site_info.is_enabled:
+                Log.error(self, "Parent site {0} is not enabled"
+                          .format(subsiteof_name))
+            if parent_site_info.site_type not in ['wpsubdomain', 'wpsubdir']:
+                Log.error(self, "Parent site {0} is not WordPress multisite"
+                          .format(subsiteof_name))
+
+            data = dict(
+                site_name=wo_domain, www_domain=wo_www_domain,
+                static=False, basic=False, multisite=False, webroot=wo_site_webroot)
+
+            data["wp"] = parent_site_info.site_type == 'wp'
+            data["wpfc"] = parent_site_info.cache_type == 'wpfc'
+            data["wpsc"] = parent_site_info.cache_type == 'wpsc'
+            data["wprocket"] = parent_site_info.cache_type == 'wprocket'
+            data["wpce"] = parent_site_info.cache_type == 'wpce'
+            data["wpredis"] = parent_site_info.cache_type == 'wpredis'
+            data["wpsubdir"] = parent_site_info.site_type == 'wpsubdir'
+            data["wo_php"]  = ("php" + parent_site_info.php_version).replace(".", "")
+            data['subsite'] = True
+            data['subsiteof_name'] = subsiteof_name
+            data['subsiteof_webroot'] = parent_site_info.site_path
 
         if stype == 'php':
             data = dict(
@@ -483,7 +522,8 @@ class WOSiteUpdateController(CementBaseController):
                version in WOVar.wo_php_versions.items()) and (stype == oldsitetype
                                                               and cache == oldcachetype
                                                               and stype != 'alias'
-                                                              and stype != 'proxy'):
+                                                              and stype != 'proxy'
+                                                              and stype != 'subsite'):
             Log.debug(self, "Nothing to update")
             return 1
 
@@ -542,6 +582,13 @@ class WOSiteUpdateController(CementBaseController):
             return 0
 
         if 'alias_name' in data.keys() and data['alias']:
+            updateSiteInfo(self, wo_domain, stype=stype, cache=cache,
+                           ssl=(bool(check_site.is_ssl)))
+            Log.info(self, "Successfully updated site"
+                     " http://{0}".format(wo_domain))
+            return 0
+        
+        if 'subsite' in data.keys() and data['subsite']:
             updateSiteInfo(self, wo_domain, stype=stype, cache=cache,
                            ssl=(bool(check_site.is_ssl)))
             Log.info(self, "Successfully updated site"

--- a/wo/cli/templates/virtualconf.mustache
+++ b/wo/cli/templates/virtualconf.mustache
@@ -45,7 +45,14 @@ server {
 
     {{^proxy}}
     {{^alias}}
+    
+    {{^subsite}}
     root {{webroot}}/htdocs;
+    {{/subsite}}
+    
+    {{#subsite}}
+    root {{subsite_webroot}}/htdocs;
+    {{/subsite}}
 
     index {{^static}}index.php{{/static}} index.html index.htm;
 

--- a/wo/cli/templates/virtualconf.mustache
+++ b/wo/cli/templates/virtualconf.mustache
@@ -51,7 +51,7 @@ server {
     {{/subsite}}
     
     {{#subsite}}
-    root {{subsite_webroot}}/htdocs;
+    root {{subsiteof_webroot}}/htdocs;
     {{/subsite}}
 
     index {{^static}}index.php{{/static}} index.html index.htm;


### PR DESCRIPTION

##### Summary

Add "Subsite Of" site type to site creation and update.  This adds another parameter to site create/update called "subsiteof."

##### Additional Information

First: I've been using Wordops to host production sites for three years now, with the majority being multisite networks consisting of > 40 sites per install.  Around 500 domains total.  This is my first code contribution to WordOps, and while this is something I can use immediately, please feel free to reject or suggest changes because this functionality will literally make my life easier on a near-daily basis.

The rationale for this change is as follows:

For large multisite wpsubdir networks, Wordpress allows you to rename the subsites to be completely different domains.  These subsite domains should have their own logging, SSL and nginx configuration, however they use the same webroot as their "parent" site.  

Example:

```
# Create multisite and add two subsites
wo site create multisite.local --wpsubdir
wo site create a.local --subsiteof multisite.local
wo site create b.local --subsiteof multisite.local

# create single site, realize mistake, and convert to subsite
wo site create singlesite.local --wp
wo site update singlesite.local --subsiteof multisite.local

```

This is addressing: https://community.wordops.net/d/1004-current-best-approach-to-wp-multisite-with-mapped-domains-tlds

Also, it may help address:
https://github.com/WordOps/WordOps/issues/106