### PR TITLE
Fix PHP{version}-FPM is not installed and fix support for php 8.3

### DIFF
--- a/wo/cli/plugins/info.py
+++ b/wo/cli/plugins/info.py
@@ -589,6 +589,93 @@ class WOInfoController(CementBaseController):
         self.app.render((data), 'info_php.mustache')
 
     @expose(hide=True)
+    def info_php83(self):
+        """Display PHP information"""
+        version = os.popen("/usr/bin/php8.3 -v 2>/dev/null | "
+                           "head -n1 | cut -d' ' -f2 |"
+                           " cut -d'+' -f1 | tr -d '\n'").read
+        config = configparser.ConfigParser()
+        config.read('/etc/php/8.3/fpm/php.ini')
+        expose_php = config['PHP']['expose_php']
+        memory_limit = config['PHP']['memory_limit']
+        post_max_size = config['PHP']['post_max_size']
+        upload_max_filesize = config['PHP']['upload_max_filesize']
+        max_execution_time = config['PHP']['max_execution_time']
+
+        if os.path.exists('/etc/php/8.3/fpm/pool.d/www.conf'):
+            config.read('/etc/php/8.3/fpm/pool.d/www.conf')
+        else:
+            Log.error(self, 'php-fpm pool config not found')
+        if config.has_section('www'):
+            wconfig = config['www']
+        elif config.has_section('www-php83'):
+            wconfig = config['www-php83']
+        else:
+            Log.error(self, 'Unable to parse configuration')
+        www_listen = wconfig['listen']
+        www_ping_path = wconfig['ping.path']
+        www_pm_status_path = wconfig['pm.status_path']
+        www_pm = wconfig['pm']
+        www_pm_max_requests = wconfig['pm.max_requests']
+        www_pm_max_children = wconfig['pm.max_children']
+        www_pm_start_servers = wconfig['pm.start_servers']
+        www_pm_min_spare_servers = wconfig['pm.min_spare_servers']
+        www_pm_max_spare_servers = wconfig['pm.max_spare_servers']
+        www_request_terminate_time = (wconfig
+                                      ['request_terminate_timeout'])
+        try:
+            www_xdebug = (wconfig
+                          ['php_admin_flag[xdebug.profiler_enable'
+                           '_trigger]'])
+        except Exception as e:
+            Log.debug(self, "{0}".format(e))
+            www_xdebug = 'off'
+
+        config.read('/etc/php/8.3/fpm/pool.d/debug.conf')
+        debug_listen = config['debug']['listen']
+        debug_ping_path = config['debug']['ping.path']
+        debug_pm_status_path = config['debug']['pm.status_path']
+        debug_pm = config['debug']['pm']
+        debug_pm_max_requests = config['debug']['pm.max_requests']
+        debug_pm_max_children = config['debug']['pm.max_children']
+        debug_pm_start_servers = config['debug']['pm.start_servers']
+        debug_pm_min_spare_servers = config['debug']['pm.min_spare_servers']
+        debug_pm_max_spare_servers = config['debug']['pm.max_spare_servers']
+        debug_request_terminate = (config['debug']
+                                         ['request_terminate_timeout'])
+        try:
+            debug_xdebug = (config['debug']['php_admin_flag[xdebug.profiler_'
+                                            'enable_trigger]'])
+        except Exception as e:
+            Log.debug(self, "{0}".format(e))
+            debug_xdebug = 'off'
+
+        data = dict(version=version, expose_php=expose_php,
+                    memory_limit=memory_limit, post_max_size=post_max_size,
+                    upload_max_filesize=upload_max_filesize,
+                    max_execution_time=max_execution_time,
+                    www_listen=www_listen, www_ping_path=www_ping_path,
+                    www_pm_status_path=www_pm_status_path, www_pm=www_pm,
+                    www_pm_max_requests=www_pm_max_requests,
+                    www_pm_max_children=www_pm_max_children,
+                    www_pm_start_servers=www_pm_start_servers,
+                    www_pm_min_spare_servers=www_pm_min_spare_servers,
+                    www_pm_max_spare_servers=www_pm_max_spare_servers,
+                    www_request_terminate_timeout=www_request_terminate_time,
+                    www_xdebug_profiler_enable_trigger=www_xdebug,
+                    debug_listen=debug_listen, debug_ping_path=debug_ping_path,
+                    debug_pm_status_path=debug_pm_status_path,
+                    debug_pm=debug_pm,
+                    debug_pm_max_requests=debug_pm_max_requests,
+                    debug_pm_max_children=debug_pm_max_children,
+                    debug_pm_start_servers=debug_pm_start_servers,
+                    debug_pm_min_spare_servers=debug_pm_min_spare_servers,
+                    debug_pm_max_spare_servers=debug_pm_max_spare_servers,
+                    debug_request_terminate_timeout=debug_request_terminate,
+                    debug_xdebug_profiler_enable_trigger=debug_xdebug)
+        self.app.render((data), 'info_php.mustache')
+
+    @expose(hide=True)
     def info_mysql(self):
         """Display MySQL information"""
         version = os.popen("/usr/bin/mysql -V | awk '{print($5)}' | "
@@ -688,6 +775,12 @@ class WOInfoController(CementBaseController):
                 self.info_php82()
             else:
                 Log.info(self, "PHP 8.2 is not installed")
+
+        if pargs.php83:
+            if WOAptGet.is_installed(self, 'php8.3-fpm'):
+                self.info_php83()
+            else:
+                Log.info(self, "PHP 8.3 is not installed")
 
         if pargs.mysql:
             if WOShellExec.cmd_exec(self, "/usr/bin/mysqladmin ping"):

--- a/wo/cli/plugins/stack_services.py
+++ b/wo/cli/plugins/stack_services.py
@@ -28,6 +28,13 @@ class WOStackStatusController(CementBaseController):
             pargs.netdata = True
             pargs.ufw = True
 
+        if pargs.php:
+            if self.app.config.has_section('php'):
+                config_php_ver = self.app.config.get(
+                    'php', 'version')
+                current_php = config_php_ver.replace(".", "")
+                setattr(self.app.pargs, 'php{0}'.format(current_php), True)
+
         if pargs.nginx:
             if os.path.exists('{0}'.format(wo_system) + 'nginx.service'):
                 services = services + ['nginx']
@@ -98,6 +105,13 @@ class WOStackStatusController(CementBaseController):
             pargs.nginx = True
             pargs.php = True
             pargs.mysql = True
+
+        if pargs.php:
+            if self.app.config.has_section('php'):
+                config_php_ver = self.app.config.get(
+                    'php', 'version')
+                current_php = config_php_ver.replace(".", "")
+                setattr(self.app.pargs, 'php{0}'.format(current_php), True)
 
         if pargs.nginx:
             if os.path.exists('{0}'.format(wo_system) + 'nginx.service'):
@@ -170,6 +184,13 @@ class WOStackStatusController(CementBaseController):
             pargs.php = True
             pargs.mysql = True
             pargs.netdata = True
+
+        if pargs.php:
+            if self.app.config.has_section('php'):
+                config_php_ver = self.app.config.get(
+                    'php', 'version')
+                current_php = config_php_ver.replace(".", "")
+                setattr(self.app.pargs, 'php{0}'.format(current_php), True)
 
         if pargs.nginx:
             if os.path.exists('{0}'.format(wo_system) + 'nginx.service'):
@@ -320,6 +341,13 @@ class WOStackStatusController(CementBaseController):
             pargs.php = True
             pargs.mysql = True
             pargs.fail2ban = True
+
+        if pargs.php:
+            if self.app.config.has_section('php'):
+                config_php_ver = self.app.config.get(
+                    'php', 'version')
+                current_php = config_php_ver.replace(".", "")
+                setattr(self.app.pargs, 'php{0}'.format(current_php), True)
 
         if pargs.nginx:
             if os.path.exists('{0}'.format(wo_system) + 'nginx.service'):

--- a/wo/core/services.py
+++ b/wo/core/services.py
@@ -170,6 +170,7 @@ class WOService():
                                                     'php8.0-fpm',
                                                     'php8.1-fpm',
                                                     'php8.2-fpm',
+                                                    'php8.3-fpm',
                                                     ]:
                 retcode = subprocess.getstatusoutput('service {0} status'
                                                      .format(service_name))


### PR DESCRIPTION
##### Summary

- Adds php8.3 info to fix missing details on `wo info` command.
- Adds php8.3 to status check, to fix empty php 8.3 on `wo stack status` command.
- Fixes incorrect log `Fix PHP{version}-FPM is not installed` issue #603 

##### Additional Information

Note, however, that the PHP service is being added 2 times, I think this wasn't intended on https://github.com/WordOps/WordOps/pull/559, please let me know if we should get rid of one of those conditionals.

```php
        if pargs.php:
            for parg_version, version in WOVar.wo_php_versions.items():
                if os.path.exists(f'{wo_system}' + f'php{version}-fpm.service'):
                    services = services + [f'php{version}-fpm']
                    
        for parg_version, version in WOVar.wo_php_versions.items():
            if (getattr(pargs, parg_version, False) and
                    os.path.exists(f'{wo_system}' + f'php{version}-fpm.service')):
                services = services + [f'php{version}-fpm']
            else:
                Log.info(self, f"PHP{version}-FPM is not installed")
```
