### PR TITLE
added null check on user

### DIFF
--- a/install
+++ b/install
@@ -830,7 +830,12 @@ wo_init() {
         fi
     fi
     if [ "$wo_force_install" = "y" ]; then
-        [ ! -f "$HOME/.gitconfig" ] && { bash -c 'echo -e "[user]\n\tname = $USER\n\temail = root@$HOSTNAME.local" > $HOME/.gitconfig'; }
+        # Check if USER is empty and assign to a variable
+        USER_OR_WORDOPS=${USER:-WordOps}
+
+        [ ! -f "$HOME/.gitconfig" ] && {
+            bash -c "echo -e \"[user]\n\tname = $USER_OR_WORDOPS\n\temail = root@$HOSTNAME.local\" > $HOME/.gitconfig";
+        }
     fi
     if [ -f ./setup.py ]; then
         wo_version_new=$(grep "version='" setup.py | awk -F "'" '{print $2}' 2>&1)


### PR DESCRIPTION
<!--
Last Thursday, I encountered an issue while installing WordOps in a Docker container using the `--silent` flag. The installation process failed because the `$USER` variable was not set properly in the Docker environment. This caused the `.gitconfig` setup step to fail with a "user not found" error. 

To resolve this, I modified the installation script to handle scenarios where `$USER` is empty by introducing a fallback value (`WordOps`). This ensures the `.gitconfig` file is always generated with a valid user name, regardless of the environment.
-->



##### Summary
 Added null check on user so that user will be initiated as WordOps when installing with --silent flag if linux $USER in empty like in docker in my case

### Original Code

```bash
if [ "$wo_force_install" = "y" ]; then
    [ ! -f "$HOME/.gitconfig" ] && {
        bash -c 'echo -e "[user]\n\tname = $USER\n\temail = root@$HOSTNAME.local" > $HOME/.gitconfig';
    }
fi

```

### Updated Code
```bash
Copy code
if [ "$wo_force_install" = "y" ]; then
    # Check if USER is empty and assign to a fallback variable
    USER_OR_WORDOPS=${USER:-WordOps}

    [ ! -f "$HOME/.gitconfig" ] && {
        bash -c "echo -e \"[user]\n\tname = $USER_OR_WORDOPS\n\temail = root@$HOSTNAME.local\" > $HOME/.gitconfig";
    }
fi
```
### Story
Last Thursday, I encountered an issue installing WordOps in a Docker container using the `--silent` flag. The installation process failed because the `$USER` variable was not set properly in the Docker environment. This caused the `.gitconfig`  user set to null so that NGINX setup failed with the error `Unable to git commit at /etc/nginx `

To resolve this, I modified the installation script to handle scenarios where `$USER` is empty by introducing a fallback value (`WordOps`). This ensures the `.gitconfig` file is always generated with a valid user name, regardless of the environment.


##### Additional Information

- Changes
Introduced a Fallback Variable: If $USER is empty, the fallback variable USER_OR_WORDOPS is set to WordOps.
Improved Compatibility: This fix ensures the script works seamlessly in Docker environments and other contexts where $USER might not be defined.
- Benefits
Fixes Installation Failures: Ensures WordOps installation does not fail due to missing $USER in Docker containers.
Increases Robustness: Makes the installation script more resilient and versatile.
Enhances Developer Experience: Provides a reliable setup process in diverse environments, saving time and avoiding errors.
