### PR TITLE
Fix AttributeError in WODownload when ConnectionError lacks reason

### DIFF
--- a/wo/core/download.py
+++ b/wo/core/download.py
@@ -29,7 +29,7 @@ class WODownload():
                     out_file.write(req.content)
                 Log.valide(self, "Downloading {0:20}".format(pkg_name))
             except requests.RequestException as e:
-                Log.debug(self, "[{err}]".format(err=str(e.reason)))
+                Log.debug(self, f"[{type(e).__name__}] {str(e)}")
                 Log.error(self, "Unable to download file, {0}"
                           .format(filename), exit=False)
                 return False


### PR DESCRIPTION
This PR fixes a bug in `wo/core/download.py` where an `AttributeError` occurs if a `ConnectionError` does not contain a `reason` attribute. This can happen in DNS resolution failures or similar network issues.

Instead of using `e.reason`, we now use a more robust logging method:

```python
Log.debug(self, f"[{type(e).__name__}] {str(e)}")
```

This ensures that all request exceptions are handled gracefully without additional tracebacks.
