### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   my_job:
     name: test WordOps


### PR DESCRIPTION
Potential fix for [https://github.com/WordOps/WordOps/security/code-scanning/9](https://github.com/WordOps/WordOps/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the workflow's steps, it primarily involves checking out the repository and running tests, so the `contents: read` permission should suffice. This ensures that the workflow has only the necessary permissions and mitigates potential security risks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
