### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/WordOps/WordOps/security/code-scanning/7](https://github.com/WordOps/WordOps/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since this workflow primarily interacts with the repository contents to build and publish a package, it only needs `contents: read`. This ensures that the workflow does not inadvertently gain unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
