### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,8 @@
 name: 'Close stale issues and PRs'
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
 on:
   schedule:
     - cron: '0 0 1 */6 *'


### PR DESCRIPTION
Potential fix for [https://github.com/WordOps/WordOps/security/code-scanning/8](https://github.com/WordOps/WordOps/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the required permissions. Since the `actions/stale` action interacts with issues and pull requests, we will grant `issues: write` and `pull-requests: write` permissions. Additionally, we will include `contents: read` as a minimal permission for accessing repository contents. This ensures the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
