### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 -   **Easy to install** : One step automated installer with migration from EasyEngine v3 support
 -   **Fast deployment** : Fast and automated WordPress, Nginx, PHP, MySQL & Redis installation
 -   **Custom Nginx build** : Nginx 1.28.0 - TLS v1.3 HTTP/3 QUIC & Brotli support
--   **Up-to-date** : PHP 7.4, 8.0, 8.1, 8.2, 8.3 & 8.4 - MariaDB 11.4 LTS & Redis 7.0
+-   **Up-to-date** : PHP 7.4, 8.0, 8.1, 8.2, 8.3, 8.4 & 8.5 - MariaDB 11.4 LTS & Redis 7.0
 -   **Secured** : Hardened WordPress security with strict Nginx location directives
 -   **Powerful** : Optimized Nginx configurations with multiple cache backends support
 -   **SSL** : Domain, Subdomain & Wildcard Let's Encrypt SSL certificates with DNS API support
@@ -123,6 +123,7 @@ wo site create example.com --php      # create example.com with [Current support
 wo site create example.com --php81      # create example.com with php 8.1 support
 wo site create example.com --php82      # create example.com with php 8.2 support
 wo site create example.com --php84      # create example.com with php 8.4 support
+wo site create example.com --php85      # create example.com with php 8.5 support
 wo site create example.com --mysql    # create example.com with php 8.2 & mysql support
 wo site create example.com --mysql --php83   # create example.com with php 8.3 & mysql support
 wo site create example.com --proxy=127.0.0.1:3000 #  create example.com with nginx as reverse-proxy
@@ -137,6 +138,7 @@ wo site update example.com --php81 # switch to PHP 8.1
 wo site update example.com --php82 # switch to PHP 8.2
 wo site update example.com --php83 # switch to PHP 8.3
 wo site update example.com --php84 # switch to PHP 8.4
+wo site update example.com --php85 # switch to PHP 8.5
 ```
 
 ### Sites secured with Let's Encrypt

--- a/config/bash_completion.d/wo_auto.rc
+++ b/config/bash_completion.d/wo_auto.rc
@@ -53,7 +53,7 @@ _wo_complete()
 
             "info")
                 COMPREPLY=( $(compgen \
-                              -W "--mysql --php --php74 --php80 --php81 --php82 --php83 --php84 --nginx" \
+                              -W "--mysql --php --php74 --php80 --php81 --php82 --php83 --php84 --php85 --nginx" \
                               -- $cur) )
                 ;;
 
@@ -74,12 +74,12 @@ _wo_complete()
             # HANDLE EVERYTHING AFTER THE THIRD LEVEL NAMESPACE
             "install" | "purge" | "remove" )
                 COMPREPLY=( $(compgen \
-                              -W "--web --admin --security --nginx --php74 --php80 --php81 --php82 --php83 --php84 --mysql --wpcli --phpmyadmin --adminer --utils --redis --phpredisadmin --composer --netdata --fail2ban --ufw --dashboard --proftpd --clamav --sendmail --ngxblocker --mysqlclient --mysqltuner --extplorer --nanorc --cheat --brotli --all --force" \
+                              -W "--web --admin --security --nginx --php74 --php80 --php81 --php82 --php83 --php84 --php85 --mysql --wpcli --phpmyadmin --adminer --utils --redis --phpredisadmin --composer --netdata --fail2ban --ufw --dashboard --proftpd --clamav --sendmail --ngxblocker --mysqlclient --mysqltuner --extplorer --nanorc --cheat --brotli --all --force" \
                               -- $cur) )
                 ;;
             "upgrade" )
                 COMPREPLY=( $(compgen \
-                              -W "--web --admin --utils --nginx --php74 --php80 --php81 --php82 --php83 --php84   --mysql --all --netdata --composer --phpmyadmin --adminer --dashboard --mysqltuner --wpcli --force" \
+                              -W "--web --admin --utils --nginx --php74 --php80 --php81 --php82 --php83 --php84 --php85 --mysql --all --netdata --composer --phpmyadmin --adminer --dashboard --mysqltuner --wpcli --force" \
                               -- $cur) )
                 ;;
             "migrate")
@@ -89,7 +89,7 @@ _wo_complete()
                 ;;
             "start" | "stop" | "reload" | "restart" | "status")
                 COMPREPLY=( $(compgen \
-                              -W "--nginx --php --php74 --php80 --php81 --php82 --php83 --php84 --mysql --redis --fail2ban --ufw --netdata -proftpd" \
+                              -W "--nginx --php --php74 --php80 --php81 --php82 --php83 --php84 --php85 --mysql --redis --fail2ban --ufw --netdata -proftpd" \
                               -- $cur) )
                 ;;
             "list")
@@ -159,13 +159,13 @@ _wo_complete()
 
             "create")
                 COMPREPLY=( $(compgen \
-                                    -W "--user --pass --email --html --php --php74 --php80 --php81 --php82 --php83 --php84  --mysql --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --proxy= --alias --subsiteof --wpredis --wprocket --wpce -le --letsencrypt  --letsencrypt=wildcard -le=wildcard --dns --dns=dns_cf --dns=dns_dgon" \
+                                    -W "--user --pass --email --html --php --php74 --php80 --php81 --php82 --php83 --php84 --php85 --mysql --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --proxy= --alias --subsiteof --wpredis --wprocket --wpce -le --letsencrypt  --letsencrypt=wildcard -le=wildcard --dns --dns=dns_cf --dns=dns_dgon" \
                                  -- $cur) )
                 ;;
 
             "update")
                 COMPREPLY=( $(compgen \
-                                    -W "--password --php --php74 --php80 --php81 --php82 --php83 --php84  --mysql --wp --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce --alias --subsiteof -le -le=off --letsencrypt --letsencrypt=off --letsencrypt=clean -le=wildcard -le=clean --dns --dns=dns_cf --dns=dns_dgon --ngxblocker --ngxblocker=off" \
+                                    -W "--password --php --php74 --php80 --php81 --php82 --php83 --php84 --php85 --mysql --wp --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce --alias --subsiteof -le -le=off --letsencrypt --letsencrypt=off --letsencrypt=clean -le=wildcard -le=clean --dns --dns=dns_cf --dns=dns_dgon --ngxblocker --ngxblocker=off" \
                                  -- $cur) )
                 ;;
             "delete")
@@ -211,9 +211,9 @@ _wo_complete()
         "--wp")
             if [ "${COMP_WORDS[1]}" != "debug" ]; then
                 if [ "${COMP_WORDS[2]}" == "create" ]; then
-                    retlist="--wp --wpsc --wpfc --user --email --pass --wpredis --wprocket --wpce --letsencrypt -le --letsencrypt=wildcard --dns --dns=dns_cf --dns=dns_dgon --php74 --php80 --php81 --php82 --php83 --php84"
+                    retlist="--wp --wpsc --wpfc --user --email --pass --wpredis --wprocket --wpce --letsencrypt -le --letsencrypt=wildcard --dns --dns=dns_cf --dns=dns_dgon --php74 --php80 --php81 --php82 --php83 --php84 --php85"
                 elif [ "${COMP_WORDS[2]}" == "update" ]; then
-                    retlist="--wp --wpfc --wpsc --php74 --php80 --php81 --php82 --php83 --php84  --wpredis --wprocket --wpce -le --letsencrypt --letsencrypt=wildcard -le=wildcard --dns --dns=dns_cf --dns=dns_dgon"
+                    retlist="--wp --wpfc --wpsc --php74 --php80 --php81 --php82 --php83 --php84 --php85 --wpredis --wprocket --wpce -le --letsencrypt --letsencrypt=wildcard -le=wildcard --dns --dns=dns_cf --dns=dns_dgon"
                 else
                     retlist=""
                 fi
@@ -230,9 +230,9 @@ _wo_complete()
         "--wpsubdir" | "--wpsubdomain")
             if [ "${COMP_WORDS[1]}" != "debug" ]; then
                 if [ "${COMP_WORDS[2]}" == "create" ]; then
-                    retlist="--wpsc --wpfc --user --email --pass --wpredis --wprocket --wpce  -le -le=wildcard --letsencrypt --letsencrypt=wildcard --php74 --php80 --php81 --php82 --php83 --php84 --dns --dns=dns_cf --dns=dns_dgon"
+                    retlist="--wpsc --wpfc --user --email --pass --wpredis --wprocket --wpce  -le -le=wildcard --letsencrypt --letsencrypt=wildcard --php74 --php80 --php81 --php82 --php83 --php84 --php85 --dns --dns=dns_cf --dns=dns_dgon"
                 elif [ "${COMP_WORDS[2]}" == "update" ]; then
-                    retlist="--wpfc --wpsc --php74 --php80 --php81 --php82 --php83 --php84 --wpredis --wprocket --wpce -le -le=wildcard --letsencrypt --letsencrypt=wildcard --dns --dns=dns_cf --dns=dns_dgon"
+                    retlist="--wpfc --wpsc --php74 --php80 --php81 --php82 --php83 --php84 --php85 --wpredis --wprocket --wpce -le -le=wildcard --letsencrypt --letsencrypt=wildcard --dns --dns=dns_cf --dns=dns_dgon"
                 else
                     retlist=""
                 fi
@@ -248,7 +248,7 @@ _wo_complete()
 
         "--wpredis" | "--wprocket" | "--wpce" | "--wpfc" | "--wpsc" | "--wpsubdir" | "--wpsubdomain" | "--user" | "--pass" | "--email" | "--wp")
             if [ "${COMP_WORDS[2]}" == "create" ]; then
-                retlist="--user --pass --email --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce --php74 --php80 --php81 --php82 --php83 --php84 -le -le=wildcard --letsencrypt --letsencrypt=wildcard --dns --dns=dns_cf --dns=dns_dgon"
+                retlist="--user --pass --email --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce --php74 --php80 --php81 --php82 --php83 --php84 --php85 -le -le=wildcard --letsencrypt --letsencrypt=wildcard --dns --dns=dns_cf --dns=dns_dgon"
             else
                 retlist=""
             fi
@@ -261,9 +261,9 @@ _wo_complete()
 
         "--wpredis" | "--wprocket" | "--wpce" | "--wpfc" | "--wpsc")
             if [ "${COMP_WORDS[2]}" == "update" ]; then
-                retlist="--password --php74 --php80 --php81 --php82 --php83 --php84 --mysql --wp  --wpsubdir --wpsubdomain -le --letsencrypt --dns --dns=dns_cf --dns=dns_dgon"
+                retlist="--password --php74 --php80 --php81 --php82 --php83 --php84 --php85 --mysql --wp  --wpsubdir --wpsubdomain -le --letsencrypt --dns --dns=dns_cf --dns=dns_dgon"
             else
-                retlist=""| "--php82" | "--php83 --php84"
+                retlist=""| "--php82" | "--php83 --php84 --php85"
             fi
 
             ret="${retlist[@]/$prev}"
@@ -272,11 +272,11 @@ _wo_complete()
                               -- $cur) )
             ;;
 
-        "--web" | "--admin" | "--nginx" | "--php" | "--php74" | "--php80" | "--php81" | "--php82" | "--php83" | "--php84" | "--mysql" | "--wpcli" | "--phpmyadmin" | "--adminer" | "--utils" | "--fail2ban" | "--ufw" | "--redis" | "--phpredisadmin" | "--netdata" | "--sendmail" | "--composer" | "--proftpd" | "--cheat" | "--nanorc" | "--clamav" | "--dashboard")
+        "--web" | "--admin" | "--nginx" | "--php" | "--php74" | "--php80" | "--php81" | "--php82" | "--php83" | "--php84" | "--php85" | "--mysql" | "--wpcli" | "--phpmyadmin" | "--adminer" | "--utils" | "--fail2ban" | "--ufw" | "--redis" | "--phpredisadmin" | "--netdata" | "--sendmail" | "--composer" | "--proftpd" | "--cheat" | "--nanorc" | "--clamav" | "--dashboard")
             if [[ "${COMP_WORDS[2]}" == "install" || "${COMP_WORDS[2]}" == "purge" || "${COMP_WORDS[2]}" == "remove" ]]; then
-                retlist="--web --admin --security --nginx --php --php74 --php80 --php81 --php82 --php83 --php84 --mysql --wpcli --phpmyadmin --adminer --utils --redis --fail2ban --ufw --phpredisadmin --netdata --force"
+                retlist="--web --admin --security --nginx --php --php74 --php80 --php81 --php82 --php83 --php84 --php85 --mysql --wpcli --phpmyadmin --adminer --utils --redis --fail2ban --ufw --phpredisadmin --netdata --force"
             elif [[ "${COMP_WORDS[2]}" == "start" || "${COMP_WORDS[2]}" == "reload" || "${COMP_WORDS[2]}" == "restart" || "${COMP_WORDS[2]}" == "stop" ]]; then
-                    retlist="--nginx --php  --php74 --php80 --php81 --php82 --php83 --php84 --mysql --redis --netdata --fail2ban --ufw"
+                    retlist="--nginx --php  --php74 --php80 --php81 --php82 --php83 --php84 --php85 --php85 --mysql --redis --netdata --fail2ban --ufw"
             elif [[ "${COMP_WORDS[1]}" == "debug" ]]; then
                     retlist="--start --nginx --php --php73 --fpm --fpm7 --mysql -i --interactive -stop --import-slow-log --import-slow-log-interval= -"
                     if [[ $prev == '--mysql' ]]; then
@@ -363,7 +363,7 @@ _wo_complete()
         case "$mprev" in
             "--user" | "--email" | "--pass")
                 if [ "${COMP_WORDS[2]}" == "create" ]; then
-                    retlist="--user --pass --email --html --php --php74 --php80 --php81 --php82 --php83 --php84 --mysql --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce -le -le=wildcard --letsencrypt --letsencrypt=wildcard --dns --dns=dns_cf --dns=dns_dgon"
+                    retlist="--user --pass --email --html --php --php74 --php80 --php81 --php82 --php83 --php84 --php85 --mysql --wp  --wpsubdir --wpsubdomain --wpfc --wpsc --wpredis --wprocket --wpce -le -le=wildcard --letsencrypt --letsencrypt=wildcard --dns --dns=dns_cf --dns=dns_dgon"
                 fi
                 ret="${retlist[@]/$prev}"
                 COMPREPLY=( $(compgen \

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -32,7 +32,7 @@ echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       stack install             '
 echo -e "${CGREEN}#############################################${CEND}"
 
-stack_list='nginx php php74 php80 php81 php82 php83 php84 mysql redis fail2ban clamav proftpd netdata phpmyadmin composer dashboard extplorer redis phpredisadmin mysqltuner utils ufw cheat nanorc'
+stack_list='nginx php php74 php80 php81 php82 php83 php84 php85 mysql redis fail2ban clamav proftpd netdata phpmyadmin composer dashboard extplorer redis phpredisadmin mysqltuner utils ufw cheat nanorc'
 
 for stack in $stack_list; do
     echo -ne "       Installing $stack               [..]\r"
@@ -52,7 +52,7 @@ done
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       Simple site create              '
 echo -e "${CGREEN}#############################################${CEND}"
-site_types='html php php74 php80 php81 php82 php83 php84 mysql wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir ngxblocker'
+site_types='html php php74 php80 php81 php82 php83 php84 php85 mysql wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir ngxblocker'
 for site in $site_types; do
     echo -ne "       Creating $site               [..]\r"
     if {
@@ -117,7 +117,7 @@ echo
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo site update --php74              '
 echo -e "${CGREEN}#############################################${CEND}"
-other_site_types='mysql php81 php82 php83 php84 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
+other_site_types='mysql php80 php81 php82 php83 php84 php85 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
 for site in $other_site_types; do
     echo -ne "       Updating site to $site php74              [..]\r"
     if {
@@ -148,7 +148,7 @@ echo
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo site update --php80             '
 echo -e "${CGREEN}#############################################${CEND}"
-other_site_types='mysql php81 php82 php84 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
+other_site_types='mysql php74 php81 php82 php83 php84 php85 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
 for site in $other_site_types; do
     echo -ne "       Updating site to $site php80              [..]\r"
     if {
@@ -171,7 +171,7 @@ echo
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo site update --php81              '
 echo -e "${CGREEN}#############################################${CEND}"
-other_site_types='mysql php82 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
+other_site_types='mysql php74 php80 php82 php83 php84 php85 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
 for site in $other_site_types; do
     echo -ne "       Updating site to $site php81              [..]\r"
     if {
@@ -192,7 +192,7 @@ echo
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo site update --php82              '
 echo -e "${CGREEN}#############################################${CEND}"
-other_site_types='mysql wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
+other_site_types='mysql php74 php80 php81 php83 php84 php85 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
 for site in $other_site_types; do
     echo -ne "       Updating site to $site php82              [..]\r"
     if {
@@ -211,18 +211,60 @@ echo
 echo -e "${CGREEN}#############################################${CEND}"
 echo
 echo -e "${CGREEN}#############################################${CEND}"
+echo -e '       wo site update --php83              '
+echo -e "${CGREEN}#############################################${CEND}"
+other_site_types='mysql php74 php80 php81 php82 php84 php85 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
+for site in $other_site_types; do
+    echo -ne "       Updating site to $site php83              [..]\r"
+    if {
+        wo site update ${site}.net --php83
+    } >>/var/log/wo/test.log; then
+        echo -ne "       Updating site to $site php83               [${CGREEN}OK${CEND}]\\r"
+        echo -ne '\n'
+    else
+        echo -e "        Updating site to $site php83              [${CRED}FAIL${CEND}]"
+        echo -ne '\n'
+        exit_script
+
+    fi
+done
+echo
+echo -e "${CGREEN}#############################################${CEND}"
+echo
+echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo site update --php84              '
 echo -e "${CGREEN}#############################################${CEND}"
-other_site_types='mysql wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
+other_site_types='mysql php74 php80 php81 php82 php83 php85 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
 for site in $other_site_types; do
     echo -ne "       Updating site to $site php84              [..]\r"
     if {
         wo site update ${site}.net --php84
     } >>/var/log/wo/test.log; then
-        echo -ne "       Updating site to $site php82               [${CGREEN}OK${CEND}]\\r"
+        echo -ne "       Updating site to $site php84               [${CGREEN}OK${CEND}]\\r"
         echo -ne '\n'
     else
-        echo -e "        Updating site to $site php82              [${CRED}FAIL${CEND}]"
+        echo -e "        Updating site to $site php84              [${CRED}FAIL${CEND}]"
+        echo -ne '\n'
+        exit_script
+
+    fi
+done
+echo
+echo -e "${CGREEN}#############################################${CEND}"
+echo
+echo -e "${CGREEN}#############################################${CEND}"
+echo -e '       wo site update --php85              '
+echo -e "${CGREEN}#############################################${CEND}"
+other_site_types='mysql php74 php80 php81 php82 php83 php84 wp wpfc wpsc wpredis wpce wprocket wpsubdomain wpsubdir'
+for site in $other_site_types; do
+    echo -ne "       Updating site to $site php85              [..]\r"
+    if {
+        wo site update ${site}.net --php85
+    } >>/var/log/wo/test.log; then
+        echo -ne "       Updating site to $site php85               [${CGREEN}OK${CEND}]\\r"
+        echo -ne '\n'
+    else
+        echo -e "        Updating site to $site php85              [${CRED}FAIL${CEND}]"
         echo -ne '\n'
         exit_script
 
@@ -297,7 +339,7 @@ if [ -z "$1" ]; then
     echo -e "${CGREEN}#############################################${CEND}"
     echo -e '       wo stack upgrade              '
     echo -e "${CGREEN}#############################################${CEND}"
-    stack_upgrade='nginx php php74 php80 php81 php82 php84 mysql redis netdata dashboard phpmyadmin adminer fail2ban composer ngxblocker mysqltuner'
+    stack_upgrade='nginx php php74 php80 php81 php82 php84 php85 mysql redis netdata dashboard phpmyadmin adminer fail2ban composer ngxblocker mysqltuner'
     for stack in $stack_upgrade; do
         echo -ne "      Upgrading $stack               [..]\r"
         if {
@@ -427,7 +469,7 @@ cat /etc/apt/sources.list.d/redis.list
 echo -e "${CGREEN}#############################################${CEND}"
 echo -e '       wo stack purge              '
 echo -e "${CGREEN}#############################################${CEND}"
-stack_purge='nginx php php74 php80 php81 php82 php83 php84 mysql redis fail2ban clamav proftpd netdata phpmyadmin composer dashboard extplorer adminer redis ufw ngxblocker cheat nanorc'
+stack_purge='nginx php php74 php80 php81 php82 php83 php84 php85 mysql redis fail2ban clamav proftpd netdata phpmyadmin composer dashboard extplorer adminer redis ufw ngxblocker cheat nanorc'
 for stack in $stack_purge; do
     echo -ne "       purging $stack              [..]\r"
     if {

--- a/wo/cli/plugins/info.py
+++ b/wo/cli/plugins/info.py
@@ -94,6 +94,11 @@ class WOInfoController(CementBaseController):
             pargs.php84 = True
         else:
             Log.info(self, "PHP 8.4 is not installed")
+        if WOAptGet.is_installed(self, 'php8.5-fpm'):
+            pargs.php85 = True
+        else:
+            Log.info(self, "PHP 8.5 is not installed")
+
 
         if pargs.php74:
             self.info_php74()
@@ -107,6 +112,8 @@ class WOInfoController(CementBaseController):
             self.info_php83()
         if pargs.php84:
             self.info_php84()
+        if pargs.php85:
+            self.info_php85()
 
     @expose(hide=True)
     def info_php74(self):
@@ -587,6 +594,93 @@ class WOInfoController(CementBaseController):
             www_xdebug = 'off'
 
         config.read('/etc/php/8.4/fpm/pool.d/debug.conf')
+        debug_listen = config['debug']['listen']
+        debug_ping_path = config['debug']['ping.path']
+        debug_pm_status_path = config['debug']['pm.status_path']
+        debug_pm = config['debug']['pm']
+        debug_pm_max_requests = config['debug']['pm.max_requests']
+        debug_pm_max_children = config['debug']['pm.max_children']
+        debug_pm_start_servers = config['debug']['pm.start_servers']
+        debug_pm_min_spare_servers = config['debug']['pm.min_spare_servers']
+        debug_pm_max_spare_servers = config['debug']['pm.max_spare_servers']
+        debug_request_terminate = (config['debug']
+                                         ['request_terminate_timeout'])
+        try:
+            debug_xdebug = (config['debug']['php_admin_flag[xdebug.profiler_'
+                                            'enable_trigger]'])
+        except Exception as e:
+            Log.debug(self, "{0}".format(e))
+            debug_xdebug = 'off'
+
+        data = dict(version=version, expose_php=expose_php,
+                    memory_limit=memory_limit, post_max_size=post_max_size,
+                    upload_max_filesize=upload_max_filesize,
+                    max_execution_time=max_execution_time,
+                    www_listen=www_listen, www_ping_path=www_ping_path,
+                    www_pm_status_path=www_pm_status_path, www_pm=www_pm,
+                    www_pm_max_requests=www_pm_max_requests,
+                    www_pm_max_children=www_pm_max_children,
+                    www_pm_start_servers=www_pm_start_servers,
+                    www_pm_min_spare_servers=www_pm_min_spare_servers,
+                    www_pm_max_spare_servers=www_pm_max_spare_servers,
+                    www_request_terminate_timeout=www_request_terminate_time,
+                    www_xdebug_profiler_enable_trigger=www_xdebug,
+                    debug_listen=debug_listen, debug_ping_path=debug_ping_path,
+                    debug_pm_status_path=debug_pm_status_path,
+                    debug_pm=debug_pm,
+                    debug_pm_max_requests=debug_pm_max_requests,
+                    debug_pm_max_children=debug_pm_max_children,
+                    debug_pm_start_servers=debug_pm_start_servers,
+                    debug_pm_min_spare_servers=debug_pm_min_spare_servers,
+                    debug_pm_max_spare_servers=debug_pm_max_spare_servers,
+                    debug_request_terminate_timeout=debug_request_terminate,
+                    debug_xdebug_profiler_enable_trigger=debug_xdebug)
+        self.app.render((data), 'info_php.mustache')
+
+    @expose(hide=True)
+    def info_php85(self):
+        """Display PHP information"""
+        version = os.popen("/usr/bin/php8.5 -v 2>/dev/null | "
+                           "head -n1 | cut -d' ' -f2 |"
+                           " cut -d'+' -f1 | tr -d '\n'").read
+        config = configparser.ConfigParser()
+        config.read('/etc/php/8.5/fpm/php.ini')
+        expose_php = config['PHP']['expose_php']
+        memory_limit = config['PHP']['memory_limit']
+        post_max_size = config['PHP']['post_max_size']
+        upload_max_filesize = config['PHP']['upload_max_filesize']
+        max_execution_time = config['PHP']['max_execution_time']
+
+        if os.path.exists('/etc/php/8.5/fpm/pool.d/www.conf'):
+            config.read('/etc/php/8.5/fpm/pool.d/www.conf')
+        else:
+            Log.error(self, 'php-fpm pool config not found')
+        if config.has_section('www'):
+            wconfig = config['www']
+        elif config.has_section('www-php85'):
+            wconfig = config['www-php85']
+        else:
+            Log.error(self, 'Unable to parse configuration')
+        www_listen = wconfig['listen']
+        www_ping_path = wconfig['ping.path']
+        www_pm_status_path = wconfig['pm.status_path']
+        www_pm = wconfig['pm']
+        www_pm_max_requests = wconfig['pm.max_requests']
+        www_pm_max_children = wconfig['pm.max_children']
+        www_pm_start_servers = wconfig['pm.start_servers']
+        www_pm_min_spare_servers = wconfig['pm.min_spare_servers']
+        www_pm_max_spare_servers = wconfig['pm.max_spare_servers']
+        www_request_terminate_time = (wconfig
+                                      ['request_terminate_timeout'])
+        try:
+            www_xdebug = (wconfig
+                          ['php_admin_flag[xdebug.profiler_enable'
+                           '_trigger]'])
+        except Exception as e:
+            Log.debug(self, "{0}".format(e))
+            www_xdebug = 'off'
+
+        config.read('/etc/php/8.5/fpm/pool.d/debug.conf')
         debug_listen = config['debug']['listen']
         debug_ping_path = config['debug']['ping.path']
         debug_pm_status_path = config['debug']['pm.status_path']

--- a/wo/cli/plugins/site_create.py
+++ b/wo/cli/plugins/site_create.py
@@ -225,7 +225,7 @@ class WOSiteCreateController(CementBaseController):
             data['subsiteof_webroot'] = parent_site_info.site_path
 
         if (pargs.php74 or pargs.php80 or pargs.php81 or
-                pargs.php82 or pargs.php83 or pargs.php84):
+                pargs.php82 or pargs.php83 or pargs.php84 or pargs.php85):
             data = dict(
                 site_name=wo_domain, www_domain=wo_www_domain,
                 static=False, basic=False,

--- a/wo/cli/plugins/site_functions.py
+++ b/wo/cli/plugins/site_functions.py
@@ -775,7 +775,7 @@ def sitebackup(self, data):
                          .format(data['site_name']), backup_path)
 
     if data['currsitetype'] in ['html', 'php', 'php72', 'php74',
-                                'php73', 'php80', 'php81', 'php82', 'php83', 'php84'
+                                'php73', 'php80', 'php81', 'php82', 'php83', 'php84', 'php85',
                                 'proxy', 'mysql']:
         if not data['wp']:
             Log.info(self, "Backing up Webroot \t\t", end='')
@@ -836,7 +836,7 @@ def site_package_check(self, stype):
     stack.app = self.app
     pargs = self.app.pargs
     if stype in ['html', 'proxy', 'php', 'mysql', 'wp', 'wpsubdir',
-                 'wpsubdomain', 'php74', 'php80', 'php81', 'php82', 'php83', 'php84', 'alias', 'subsite']:
+                 'wpsubdomain', 'php74', 'php80', 'php81', 'php82', 'php83', 'php84', 'php85', 'alias', 'subsite']:
         Log.debug(self, "Setting apt_packages variable for Nginx")
 
         # Check if server has nginx-custom package
@@ -872,7 +872,7 @@ def site_package_check(self, stype):
                     wo_nginx.write('fastcgi_param \tSCRIPT_FILENAME '
                                    '\t$request_filename;\n')
 
-        php_versions = ['php74', 'php80', 'php81', 'php82', 'php83', 'php84']
+        php_versions = ['php74', 'php80', 'php81', 'php82', 'php83', 'php84', 'php85']
 
         selected_versions = [version for version in php_versions if getattr(pargs, version)]
         if len(selected_versions) > 1:
@@ -882,6 +882,7 @@ def site_package_check(self, stype):
     if ((not pargs.php74) and (not pargs.php80) and
         (not pargs.php81) and (not pargs.php82) and
         (not pargs.php83) and (not pargs.php84) and
+        (not pargs.php85) and
         stype in ['php', 'mysql', 'wp', 'wpsubdir',
                   'wpsubdomain']):
         Log.debug(self, "Setting apt_packages variable for PHP")
@@ -1080,7 +1081,7 @@ def detSitePar(opts):
     for key, val in opts.items():
         if val and key in ['html', 'php', 'mysql', 'wp',
                            'wpsubdir', 'wpsubdomain',
-                           'php74', 'php80', 'php81', 'php82', 'php83', 'php84']:
+                           'php74', 'php80', 'php81', 'php82', 'php83', 'php84', 'php85']:
             typelist.append(key)
         elif val and key in ['wpfc', 'wpsc', 'wpredis', 'wprocket', 'wpce']:
             cachelist.append(key)
@@ -1132,6 +1133,12 @@ def detSitePar(opts):
                 cachetype = 'basic'
             else:
                 cachetype = cachelist[0]
+        elif False not in [x in ('php85', 'mysql', 'html') for x in typelist]:
+            sitetype = 'mysql'
+            if not cachelist:
+                cachetype = 'basic'
+            else:
+                cachetype = cachelist[0]
         elif False not in [x in ('php', 'mysql') for x in typelist]:
             sitetype = 'mysql'
             if not cachelist:
@@ -1169,6 +1176,12 @@ def detSitePar(opts):
             else:
                 cachetype = cachelist[0]
         elif False not in [x in ('php84', 'mysql') for x in typelist]:
+            sitetype = 'mysql'
+            if not cachelist:
+                cachetype = 'basic'
+            else:
+                cachetype = cachelist[0]
+        elif False not in [x in ('php85', 'mysql') for x in typelist]:
             sitetype = 'mysql'
             if not cachelist:
                 cachetype = 'basic'
@@ -1234,6 +1247,12 @@ def detSitePar(opts):
                 cachetype = 'basic'
             else:
                 cachetype = cachelist[0]
+        elif False not in [x in ('wp', 'php85') for x in typelist]:
+            sitetype = 'wp'
+            if not cachelist:
+                cachetype = 'basic'
+            else:
+                cachetype = cachelist[0]
         elif False not in [x in ('wpsubdir', 'php74') for x in typelist]:
             sitetype = 'wpsubdir'
             if not cachelist:
@@ -1265,6 +1284,12 @@ def detSitePar(opts):
             else:
                 cachetype = cachelist[0]
         elif False not in [x in ('wpsubdir', 'php84') for x in typelist]:
+            sitetype = 'wpsubdir'
+            if not cachelist:
+                cachetype = 'basic'
+            else:
+                cachetype = cachelist[0]
+        elif False not in [x in ('wpsubdir', 'php85') for x in typelist]:
             sitetype = 'wpsubdir'
             if not cachelist:
                 cachetype = 'basic'
@@ -1306,6 +1331,12 @@ def detSitePar(opts):
                 cachetype = 'basic'
             else:
                 cachetype = cachelist[0]
+        elif False not in [x in ('wpsubdomain', 'php85') for x in typelist]:
+            sitetype = 'wpsubdomain'
+            if not cachelist:
+                cachetype = 'basic'
+            else:
+                cachetype = cachelist[0]
         else:
             raise RuntimeError("could not determine site and cache type")
     else:
@@ -1328,6 +1359,9 @@ def detSitePar(opts):
             sitetype = 'wp'
             cachetype = cachelist[0]
         elif (not typelist or "php84" in typelist) and cachelist:
+            sitetype = 'wp'
+            cachetype = cachelist[0]
+        elif (not typelist or "php85" in typelist) and cachelist:
             sitetype = 'wp'
             cachetype = cachelist[0]
         elif typelist and (not cachelist):

--- a/wo/cli/plugins/site_update.py
+++ b/wo/cli/plugins/site_update.py
@@ -269,7 +269,7 @@ class WOSiteUpdateController(CementBaseController):
 
         if (((stype == 'php' and
               oldsitetype not in ['html', 'proxy', 'php', 'php74', 'php80',
-                                  'php81', 'php82', 'php83', 'php84']) or
+                                  'php81', 'php82', 'php83', 'php84', 'php85']) or
              (stype == 'mysql' and oldsitetype not in [
                  'html', 'php', 'php74', 'php80', 'php81',
                  'php82', 'php83', 'php84', 'php85', 'proxy']) or

--- a/wo/cli/plugins/site_update.py
+++ b/wo/cli/plugins/site_update.py
@@ -197,8 +197,9 @@ class WOSiteUpdateController(CementBaseController):
         if ((pargs.password or pargs.hsts or
              pargs.ngxblocker or pargs.letsencrypt == 'renew') and not (
             pargs.html or pargs.php or pargs.php74 or pargs.php80 or
-            pargs.php81 or pargs.php82 or
-            pargs.php83 or pargs.php84 or pargs.mysql or pargs.wp or pargs.wpfc or pargs.wpsc or
+            pargs.php81 or pargs.php82 or pargs.php83 or
+            pargs.php84 or pargs.php85 or
+            pargs.mysql or pargs.wp or pargs.wpfc or pargs.wpsc or
             pargs.wprocket or pargs.wpce or
                 pargs.wpsubdir or pargs.wpsubdomain)):
 
@@ -271,16 +272,16 @@ class WOSiteUpdateController(CementBaseController):
                                   'php81', 'php82', 'php83', 'php84']) or
              (stype == 'mysql' and oldsitetype not in [
                  'html', 'php', 'php74', 'php80', 'php81',
-                 'php82', 'php83', 'php84', 'proxy']) or
+                 'php82', 'php83', 'php84', 'php85', 'proxy']) or
              (stype == 'wp' and oldsitetype not in [
                  'html', 'php', 'php74', 'php80', 'php81',
-                 'php82', 'php83', 'php84', 'mysql', 'proxy', 'wp']) or
+                 'php82', 'php83', 'php84', 'php85', 'mysql', 'proxy', 'wp']) or
              (stype == 'wpsubdir' and oldsitetype in ['wpsubdomain']) or
              (stype == 'wpsubdomain' and oldsitetype in ['wpsubdir']) or
              (stype == oldsitetype and cache == oldcachetype)) and
                 not (pargs.php74 or pargs.php80 or
                      pargs.php81 or pargs.php82 or
-                     pargs.php83 or pargs.php84 or pargs.alias)):
+                     pargs.php83 or pargs.php84 or pargs.php85 or pargs.alias)):
             Log.info(self, Log.FAIL + "can not update {0} {1} to {2} {3}".
                      format(oldsitetype, oldcachetype, stype, cache))
             return 1
@@ -338,7 +339,7 @@ class WOSiteUpdateController(CementBaseController):
                 site_name=wo_domain, www_domain=wo_www_domain,
                 static=False, basic=True, wp=False, wpfc=False,
                 php74=False, php80=False, php81=False, php82=False, php83=False,
-                php84=False, wpsc=False, wpredis=False, wprocket=False, wpce=False,
+                php84=False, php85=False, wpsc=False, wpredis=False, wprocket=False, wpce=False,
                 multisite=False, wpsubdir=False, webroot=wo_site_webroot,
                 currsitetype=oldsitetype, currcachetype=oldcachetype)
 
@@ -362,11 +363,11 @@ class WOSiteUpdateController(CementBaseController):
                     data['wpsubdir'] = True
 
         if ((pargs.php74 or pargs.php80 or pargs.php81 or
-             pargs.php82 or pargs.php83 or pargs.php84) and
+             pargs.php82 or pargs.php83 or pargs.php84 or pargs.php85) and
                 (not data)):
             Log.debug(
                 self, "pargs php74, "
-                "or php80, or php81 or php82 or php83 or php84 enabled")
+                "or php80, or php81 or php82 or php83 or php84 or php85 enabled")
             data = dict(
                 site_name=wo_domain,
                 www_domain=wo_www_domain,
@@ -384,7 +385,7 @@ class WOSiteUpdateController(CementBaseController):
                   oldsitetype == 'php73' or oldsitetype == 'php74' or
                   oldsitetype == 'php80' or oldsitetype == 'php81' or
                   oldsitetype == 'php82' or oldsitetype == 'php83' or
-                  oldsitetype == 'php84'):
+                  oldsitetype == 'php84' or oldsitetype == 'php85'):
                 data['static'] = False
                 data['wp'] = False
                 data['multisite'] = False
@@ -436,7 +437,7 @@ class WOSiteUpdateController(CementBaseController):
 
             if (data and (not pargs.php74) and
                     (not pargs.php80) and (not pargs.php81) and (not pargs.php82)
-                    and (not pargs.php83) and (not pargs.php84)):
+                    and (not pargs.php83) and (not pargs.php84) and (not pargs.php85)):
                 data[pargs_version] = bool(old_version_var is True)
                 Log.debug(
                     self, f"data {pargs_version} = {data[pargs_version]}")
@@ -796,7 +797,8 @@ class WOSiteUpdateController(CementBaseController):
         # Setup WordPress if old sites are html/php/mysql sites
         if data['wp'] and oldsitetype in ['html', 'proxy', 'php', 'php72',
                                           'mysql', 'php73', 'php74', 'php80',
-                                          'php81', 'php82', 'php83', 'php84']:
+                                          'php81', 'php82', 'php83', 'php84',
+                                          'php85']:
             try:
                 wo_wp_creds = setupwordpress(self, data)
             except SiteError as e:

--- a/wo/cli/plugins/stack.py
+++ b/wo/cli/plugins/stack.py
@@ -136,6 +136,7 @@ class WOStackController(CementBaseController):
                 pargs.php82 = True
                 pargs.php83 = True
                 pargs.php84 = True
+                pargs.php85 = True
                 pargs.redis = True
                 pargs.proftpd = True
 
@@ -194,6 +195,8 @@ class WOStackController(CementBaseController):
                 'php82': WOVar.wo_php82,
                 'php83': WOVar.wo_php83,
                 'php84': WOVar.wo_php84,
+                'php85': WOVar.wo_php85,
+
             }
 
             for parg_version, version in WOVar.wo_php_versions.items():
@@ -480,7 +483,8 @@ class WOStackController(CementBaseController):
                         WOAptGet.is_installed(self, 'php8.1-fpm') or
                         WOAptGet.is_installed(self, 'php8.2-fpm') or
                         WOAptGet.is_installed(self, 'php8.3-fpm') or
-                        WOAptGet.is_installed(self, 'php8.4-fpm')):
+                        WOAptGet.is_installed(self, 'php8.4-fpm') or
+                        WOAptGet.is_installed(self, 'php8.5-fpm')):
                     pargs.php = True
                 Log.debug(self, "Setting packages variable for utils")
                 packages = packages + [[
@@ -581,6 +585,7 @@ class WOStackController(CementBaseController):
             pargs.php82 = True
             pargs.php83 = True
             pargs.php84 = True
+            pargs.php85 = True
             pargs.fail2ban = True
             pargs.proftpd = True
             pargs.utils = True
@@ -623,6 +628,7 @@ class WOStackController(CementBaseController):
             'php82': WOVar.wo_php82,
             'php83': WOVar.wo_php83,
             'php84': WOVar.wo_php84,
+            'php85': WOVar.wo_php85,
         }
 
         # Loop through all versions.
@@ -904,6 +910,7 @@ class WOStackController(CementBaseController):
             pargs.php82 = True
             pargs.php83 = True
             pargs.php84 = True
+            pargs.php85 = True
             pargs.fail2ban = True
             pargs.proftpd = True
             pargs.utils = True
@@ -946,6 +953,7 @@ class WOStackController(CementBaseController):
             'php82': WOVar.wo_php82,
             'php83': WOVar.wo_php83,
             'php84': WOVar.wo_php84,
+            'php85': WOVar.wo_php85,
         }
 
         for parg_version, version in WOVar.wo_php_versions.items():

--- a/wo/cli/plugins/stack_pref.py
+++ b/wo/cli/plugins/stack_pref.py
@@ -86,7 +86,8 @@ def pre_pref(self, apt_packages):
             ('php8.1-fpm' in apt_packages) or
             ('php8.2-fpm' in apt_packages) or
             ('php8.3-fpm' in apt_packages) or
-            ('php8.4-fpm' in apt_packages)):
+            ('php8.4-fpm' in apt_packages) or
+            ('php8.5-fpm' in apt_packages)):
         if (WOVar.wo_distro == 'ubuntu'):
             Log.debug(self, 'Adding ppa for PHP')
             Log.info(self, "Adding repository for PHP, please wait...")

--- a/wo/cli/plugins/stack_upgrade.py
+++ b/wo/cli/plugins/stack_upgrade.py
@@ -108,6 +108,7 @@ class WOStackUpgradeController(CementBaseController):
             pargs.php82 = True
             pargs.php83 = True
             pargs.php84 = True
+            pargs.php85 = True
             pargs.mysql = True
             pargs.wpcli = True
 
@@ -142,6 +143,7 @@ class WOStackUpgradeController(CementBaseController):
             'php82': WOVar.wo_php82,
             'php83': WOVar.wo_php83,
             'php84': WOVar.wo_php84,
+            'php85': WOVar.wo_php85,
         }
 
         for parg_version, version in WOVar.wo_php_versions.items():
@@ -282,6 +284,7 @@ class WOStackUpgradeController(CementBaseController):
                         "php8.2-fpm" in apt_packages or
                         "php8.3-fpm" in apt_packages or
                         "php8.4-fpm" in apt_packages or
+                        "php8.5-fpm" in apt_packages or
                         "redis-server" in apt_packages or
                         "nginx-custom" in apt_packages or
                         "mariadb-server" in apt_packages):

--- a/wo/cli/templates/upstream.mustache
+++ b/wo/cli/templates/upstream.mustache
@@ -186,6 +186,26 @@ upstream debug84 {
 }
 
 #-------------------------------
+# PHP 8.5
+#-------------------------------
+
+# PHP 8.5 upstream with load-balancing on two unix sockets
+upstream php85 {
+    least_conn;
+
+    server unix:/var/run/php/php85-fpm.sock;
+    server unix:/var/run/php/php85-two-fpm.sock;
+
+    keepalive 5;
+}
+
+# PHP 8.5 debug
+upstream debug85 {
+    # Debug Pool
+    server 127.0.0.1:9180;
+}
+
+#-------------------------------
 # Netdata
 #-------------------------------
 
@@ -219,4 +239,5 @@ upstream multiphp {
     server unix:/var/run/php/php82-fpm.sock;
     server unix:/var/run/php/php83-fpm.sock;
     server unix:/var/run/php/php84-fpm.sock;
+    server unix:/var/run/php/php85-fpm.sock;
 }

--- a/wo/core/services.py
+++ b/wo/core/services.py
@@ -172,6 +172,7 @@ class WOService():
                                                     'php8.2-fpm',
                                                     'php8.3-fpm',
                                                     'php8.4-fpm',
+                                                    'php8.5-fpm',
                                                     ]:
                 retcode = subprocess.getstatusoutput('service {0} status'
                                                      .format(service_name))

--- a/wo/core/variables.py
+++ b/wo/core/variables.py
@@ -150,6 +150,7 @@ class WOVar():
         'php82': '8.2',
         'php83': '8.3',
         'php84': '8.4',
+        'php85': '8.5',
     }
 
     def generate_php_modules(version_prefix, version_number):
@@ -171,6 +172,7 @@ class WOVar():
     wo_php82 = generate_php_modules('php82', '8.2')
     wo_php83 = generate_php_modules('php83', '8.3')
     wo_php84 = generate_php_modules('php84', '8.4')
+    wo_php85 = generate_php_modules('php85', '8.5')
 
     wo_php_extra = ["graphviz"]
 

--- a/wo/core/variables.py
+++ b/wo/core/variables.py
@@ -155,14 +155,21 @@ class WOVar():
 
     def generate_php_modules(version_prefix, version_number):
         wo_module = ["bcmath", "cli", "common", "curl", "fpm", "gd", "igbinary",
-                     "imagick", "imap", "intl", "mbstring", "memcached", "msgpack",
-                     "mysql", "opcache", "readline", "redis", "soap", "xdebug",
-                     "xml", "zip"]
+                    "imagick", "imap", "intl", "mbstring", "memcached", "msgpack",
+                    "mysql", "readline", "redis", "soap", "xdebug",
+                    "xml", "zip"]
+
+        # opcache is bundled in PHP 8.5+
+        if version_number != '8.5':
+            wo_module.append("opcache")
+
         php_modules = ["php{0}-{1}".format(version_number, module) for module in wo_module]
 
         if version_prefix == 'php74':
-            php_modules.extend(["php{0}-geoip".format(version_number),
-                                "php{0}-json".format(version_number)])
+            php_modules.extend([
+                "php{0}-geoip".format(version_number),
+                "php{0}-json".format(version_number)
+            ])
 
         return php_modules
 


### PR DESCRIPTION
##### Summary
Add experimental support for PHP 8.5 in WordOps.

This change extends the supported PHP versions to include PHP 8.5 across:
- CLI options (e.g. --php85)
- Stack installation and upgrade logic
- Nginx upstream configuration templates

The implementation follows the existing pattern used for previous PHP versions
to maintain consistency and backward compatibility.

Note: This relies on PHP 8.5 being available via system repositories
(e.g. Ondrej PPA).

##### Additional Information
- Tested on Ubuntu environment (CI checks passed successfully on both Ubuntu 22.04 and 24.04.)
- Verified successful installation of php8.5-fpm
- Confirmed Nginx upstream configuration is generated correctly
- No breaking changes introduced for existing PHP versions (7.4 & 8.0 → 8.4)
- In PHP 8.5, the opcache extension is bundled and no longer available as a separate package (php8.5-opcache).
  To prevent installation failures, opcache is excluded for PHP 8.5.

This PR intentionally avoids introducing any architectural changes
and keeps modifications minimal and aligned with existing code structure.