### PR TITLE
locations: serve missing .css/.js with correct Content-Type

### DIFF
--- a/wo/cli/templates/locations.mustache
+++ b/wo/cli/templates/locations.mustache
@@ -18,13 +18,38 @@ location ~* \.(ogg|ogv|svg|svgz|eot|otf|woff|woff2|ttf|m4a|mp4|ttf|rss|atom|jpe?
     log_not_found off;
     expires max;
 }
-# Cache css & js files
-location ~* \.(?:css(\.map)?|js(\.map)?)$ {
+# Cache css files
+# Missing files return a 404 with Content-Type: text/css so browsers' strict
+# MIME checking doesn't block dynamically generated stylesheets (Divi Dynamic
+# Assets, WP Rocket critical CSS, Autoptimize, LiteSpeed Cache CCSS, etc.)
+# when the file is referenced from cached HTML before it has been written.
+location ~* \.css(\.map)?$ {
     more_set_headers "Access-Control-Allow-Origin: *";
     more_set_headers "Cache-Control: public, no-transform";
     access_log off;
     log_not_found off;
     expires 1y;
+    try_files $uri =404;
+    error_page 404 = @css_not_found;
+}
+location @css_not_found {
+    default_type text/css;
+    return 404 "/* not found */\n";
+}
+# Cache js files
+# Same rationale as the css block above: missing files stay application/javascript.
+location ~* \.js(\.map)?$ {
+    more_set_headers "Access-Control-Allow-Origin: *";
+    more_set_headers "Cache-Control: public, no-transform";
+    access_log off;
+    log_not_found off;
+    expires 1y;
+    try_files $uri =404;
+    error_page 404 = @js_not_found;
+}
+location @js_not_found {
+    default_type application/javascript;
+    return 404 "// not found\n";
 }
 # Security settings for better privacy
 # Deny hidden files


### PR DESCRIPTION
##### Summary

Fixes #776.

The generic css/js location in `wo/cli/templates/locations.mustache` has no `try_files` or `default_type`, so when a requested `.css` / `.js` file is missing, nginx returns its default `text/html` 404 page. Browsers with strict MIME checking (Chrome, Firefox, Edge) block those responses:

```
Refused to apply style from '.../file.css' because its MIME type
('text/html') is not a supported stylesheet MIME type, and strict MIME
checking is enabled.
```

This breaks sites that generate CSS/JS on demand — Divi Dynamic Assets (`/wp-content/et-cache/...`), WP Rocket critical CSS, Autoptimize, LiteSpeed Cache CCSS, … — whenever the HTML is served from cache before the generator has written the file. See the linked issue for full reproduction.

##### Change

Split the combined css/js block in two, add `try_files $uri =404` and a named `error_page` location per type that sets the correct `default_type` on the 404 response:

- `.css` → 404 with `Content-Type: text/css`
- `.js`  → 404 with `Content-Type: application/javascript`

All other behavior (CORS, cache-control, expires 1y, quiet logs) is preserved. Existing files are still served at 200 with their normal MIME type — nginx still uses the compiled `mime.types` for successful responses; `default_type` only takes effect on the 404 body.

##### Additional Information

Syntax-tested with `nginx -t`. End-to-end verified on a WordOps-managed host running Divi (the original repro):

```bash
# Before fix
curl -sI https://example.tld/wp-content/et-cache/9999/missing.css
# HTTP/2 404
# content-type: text/html   ← Chrome blocks

# After fix
curl -sI https://example.tld/wp-content/et-cache/9999/missing.css
# HTTP/2 404
# content-type: text/css    ← Chrome accepts the 404

curl -sI https://example.tld/wp-content/themes/twentytwentyfour/style.css
# HTTP/2 200
# content-type: text/css    ← unchanged for existing files
```
