### PR TITLE
fix(acme): prevent directory creation crash and correct acme.sh installation command syntax

### DIFF
--- a/wo/core/acme.py
+++ b/wo/core/acme.py
@@ -27,14 +27,17 @@ class WOAcme:
             WOGit.clone(
                 self, 'https://github.com/Neilpang/acme.sh.git',
                 '/opt/acme.sh', branch='master')
-            WOFileUtils.mkdir(self, '/etc/letsencrypt/config')
-            WOFileUtils.mkdir(self, '/etc/letsencrypt/renewal')
-            WOFileUtils.mkdir(self, '/etc/letsencrypt/live')
+            if not os.path.exists('/etc/letsencrypt/config'):
+                WOFileUtils.mkdir(self, '/etc/letsencrypt/config')
+            if not os.path.exists('/etc/letsencrypt/renewal'):
+                WOFileUtils.mkdir(self, '/etc/letsencrypt/renewal')
+            if not os.path.exists('/etc/letsencrypt/live'):
+                WOFileUtils.mkdir(self, '/etc/letsencrypt/live')
             try:
                 WOFileUtils.chdir(self, '/opt/acme.sh')
                 WOShellExec.cmd_exec(
-                    self, './acme.sh --install --home /etc/letsencrypt'
-                    '--config-home /etc/letsencrypt/config'
+                    self, './acme.sh --install --home /etc/letsencrypt '
+                    '--config-home /etc/letsencrypt/config '
                     '--cert-home /etc/letsencrypt/renewal'
                 )
                 WOShellExec.cmd_exec(


### PR DESCRIPTION
### Description
This Pull Request fixes two bugs in the `WOAcme.check_acme()` function in `wo/core/acme.py` that occur when WordOps attempts to automatically reinstall `acme.sh`.

### Bug 1: Directory creation crash when they already exist
* **Issue:** WordOps blindly runs `WOFileUtils.mkdir()` on `/etc/letsencrypt/config`, `/etc/letsencrypt/renewal`, and `/etc/letsencrypt/live` if `/etc/letsencrypt/acme.sh` is missing. Since `WOFileUtils.mkdir()` throws a fatal error if the directory already exists (`FileExistsError`), WordOps crashes with `Unable to create directory /etc/letsencrypt/config` and aborts execution.
* **Fix:** Added `if not os.path.exists(...)` checks before creating the directories.

### Bug 2: Invalid syntax for the `acme.sh` installation command
* **Issue:** Due to Python's implicit string concatenation without ending spaces, the install command was being evaluated as:
  `./acme.sh --install --home /etc/letsencrypt--config-home /etc/letsencrypt/config--cert-home /etc/letsencrypt/renewal`
  which has invalid flag names and causes the installation to fail.
* **Fix:** Added missing spaces to the ends of concatenated lines to form the proper command:
  `./acme.sh --install --home /etc/letsencrypt --config-home /etc/letsencrypt/config --cert-home /etc/letsencrypt/renewal`

### Verification
Tested the changes on a clean server. WordOps is now able to successfully install `acme.sh` when missing, skipping directory creation if they already exist, and using the correct syntax for installation.